### PR TITLE
Switch to crypto/rand and add int() rand functions

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -22,7 +22,7 @@ func RandIntRange(min, max int) int {
 	return int(n.Int64() + int64(min))
 }
 
-// RandPositiveInt generates a non-negative crypto-random number in the half-open interval [0,n).
+// RandPositiveInt generates a non-negative crypto-random number in the half-open interval [0,max).
 func RandPositiveInt(max int) int {
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
 	if err != nil {

--- a/random/random.go
+++ b/random/random.go
@@ -1,7 +1,8 @@
 package random
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 )
 
 var (
@@ -10,10 +11,31 @@ var (
 	digits  = []rune("0123456789")
 )
 
+// RandIntRange generates a `int` between [min,max).
+func RandIntRange(min, max int) int {
+	rangeMax := big.NewInt(int64(max) - int64(min))
+	n, err := rand.Int(rand.Reader, rangeMax)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(n.Int64() + int64(min))
+}
+
+// RandPositiveInt generates a non-negative crypto-random number in the half-open interval [0,n).
+func RandPositiveInt(max int) int {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		panic(err)
+	}
+
+	return int(n.Int64())
+}
+
 func RandLetters(n int) string {
 	runeSlice := make([]rune, n)
 	for i := range runeSlice {
-		runeSlice[i] = letters[rand.Intn(len(letters))]
+		runeSlice[i] = letters[RandPositiveInt(len(letters))]
 	}
 
 	return string(runeSlice)
@@ -21,13 +43,13 @@ func RandLetters(n int) string {
 
 // RandLettersRange generates a random alpha string of length [min,max).
 func RandLettersRange(min, max int) string {
-	return RandLetters(rand.Intn(max-min) + min)
+	return RandLetters(RandIntRange(min, max-1))
 }
 
 func RandHex(n int) string {
 	runeSlice := make([]rune, n)
 	for i := range runeSlice {
-		runeSlice[i] = hex[rand.Intn(len(hex))]
+		runeSlice[i] = hex[RandPositiveInt(len(hex))]
 	}
 
 	return string(runeSlice)
@@ -35,19 +57,19 @@ func RandHex(n int) string {
 
 // RandHexRange generates a random hex string of length [min,max).
 func RandHexRange(min, max int) string {
-	return RandHex(rand.Intn(max-min) + min)
+	return RandHex(RandIntRange(min, max-1))
 }
 
 func RandDigits(n int) string {
 	runeSlice := make([]rune, n)
 	for i := range runeSlice {
-		runeSlice[i] = digits[rand.Intn(len(digits))]
+		runeSlice[i] = digits[RandPositiveInt(len(digits))]
 	}
 
 	// keep assigning a new digit until the first one isn't 0'
 	if len(runeSlice) > 0 {
 		for runeSlice[0] == '0' {
-			runeSlice[0] = digits[rand.Intn(len(digits))]
+			runeSlice[0] = digits[RandPositiveInt(len(digits))]
 		}
 	}
 
@@ -56,5 +78,5 @@ func RandDigits(n int) string {
 
 // RandDigitsRange generates a random numeric string of length [min,max).
 func RandDigitsRange(min, max int) string {
-	return RandDigits(rand.Intn(max-min) + min)
+	return RandDigits(RandIntRange(min, max))
 }

--- a/random/random.go
+++ b/random/random.go
@@ -11,7 +11,7 @@ var (
 	digits  = []rune("0123456789")
 )
 
-// RandIntRange generates a `int` between [min,max).
+// RandIntRange generates an `int` between [min,max).
 func RandIntRange(min, max int) int {
 	rangeMax := big.NewInt(int64(max) - int64(min))
 	n, err := rand.Int(rand.Reader, rangeMax)

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -4,6 +4,26 @@ import (
 	"testing"
 )
 
+func Test_RandPositiveInt(t *testing.T) {
+	integer := RandPositiveInt(10)
+	if integer > 10 {
+		t.Error("Integer larger than 10")
+	}
+	if integer < 0 {
+		t.Error("Positive integer less than 0")
+	}
+}
+
+func Test_RandIntRange(t *testing.T) {
+	integer := RandIntRange(-2, 10)
+	if integer > 10 {
+		t.Error("Integer larger than 10")
+	}
+	if integer < -2 {
+		t.Error("Integer less than -2")
+	}
+}
+
 func Test_RandLetters(t *testing.T) {
 	letters := RandLetters(8)
 	if len(letters) != 8 {


### PR DESCRIPTION
This moves the random functions to utilize `crypto/rand` for cryptographic safe pseudo-random. These go APIs can be a little unruly since they use `math/big` and require some type coersions that aren't ideal, but shouldn't be an issue since the functions utilize `int` and not `int64` types. This adds the following functions:

- `RandPositiveInt` which generates a positive integer in half-open interval to match the other functions.
- `RandIntRange` which  generates a integer between `[min,max)`

Two other things that might come up with this; adding panics seems bad (but the `rand.Intn` utilizes these as well just internally) and this will break deterministic tests (though the current `math/rand` don't utilize seeds in the tests anyway so this may be a non-issue for now).

And for continuity here the lint and test runs:

```
$ golangci-lint run
WARN [linters_context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters_context] wastedassign is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.

$ go test -count 10000
PASS
ok  	github.com/vulncheck-oss/go-exploit/random	2.221s
```