### PR TITLE
Update docs and fix wording on lhost/lport flags

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -62,8 +62,8 @@ func remoteHostFlags(conf *config.Config) {
 
 // command line flags for defining the local host.
 func localHostFlags(conf *config.Config) {
-	flag.StringVar(&conf.Lhost, "lhost", "", "The IP address to send the reverse shell or infoleak to")
-	flag.IntVar(&conf.Lport, "lport", 0, "The port to send the reverse shell or infoleak to")
+	flag.StringVar(&conf.Lhost, "lhost", "", "The IP address the configured c2 will bind to")
+	flag.IntVar(&conf.Lport, "lport", 0, "The port the configured c2 will bind to")
 }
 
 // command line flags that control the exploits behavior.

--- a/docs/c2.md
+++ b/docs/c2.md
@@ -3,6 +3,7 @@ In `go-exploit`, the command and control (C2) functionality provides a basic com
 1. *SimpleShellClient* - An unencrypted terminal via a bind shell.
 2. *SimpleShellServer* - An unencrypted terminal via a reverse shell.
 3. *SSLShellServer* - An encrypted terminal via a reverse shell.
+4. *HTTPServeFile* - An unencrypted HTTP server that serves a user configured file (not a traditional c2)
 
 These C2 types allow the attacker to interact with the compromised machine through a command-line interface. However, they don't currently offer advanced features. The C2 interface in `go-exploit` is designed to be flexible, making it suitable for future development and expansion.
 


### PR DESCRIPTION
-lhost and -lport are now more aligned to what they actually are (since I muddied the water with HTTPServeFile)

```
albinolobster@mournland:~/go-exploit/examples/cve-2022-44877$ ./cve-2022-44877 -h
An exploit for CentOS Web Panel CVE-2022-44877 that can generate a reverse shell or bind shell

  -a	Automatically determine if the remote target uses SSL
  -bport int
    	The port to attach the bind shell to
  -c	Perform a version check before attempting exploitation
  -c2 string
    	The C2 server implementation to use. Supported: 
    		SSLShellServer
    		SimpleShellServer
    		SimpleShellClient
    		HTTPServeFile
    	 (default "SSLShellServer")
  -e	Exploit the target
  -httpServeFile.FileToServe string
    	The file to serve on the HTTP server
  -httpServeFile.ServerField string
    	The value to insert in the HTTP server field (default "Apache")
  -lhost string
    	The IP address the configured c2 will bind to
  -lport int
    	The port the configured c2 will bind to
  -o	Indicates if the reverse shell should be caught by an outside program (nc, openssl)
  -rhost string
    	The remote target's IP address
  -rport int
    	The remote target's server port (default 2031)
  -s	Use https to communicate with the target
  -t int
    	The number of seconds to listen for reverse shells. (default 30)
  -v	Verify the target is CentOS Web Panel
```