### PR TITLE
Add protocol.ParseCookies

### DIFF
--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -32,6 +32,18 @@ func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
 	return url
 }
 
+// ParseCookies parses an HTTP response and returns a string suitable for a Cookie header.
+func ParseCookies(resp *http.Response) string {
+	headers := resp.Header.Values("Set-Cookie")
+	cookies := make([]string, len(headers))
+
+	for i, cookie := range headers {
+		cookies[i] = strings.Split(cookie, ";")[0]
+	}
+
+	return strings.Join(cookies, "; ")
+}
+
 // Go doesn't always like sending our exploit URI so use this raw version. SSL not implemented.
 func DoRawHTTPRequest(rhost string, rport int, uri string, verb string) bool {
 	// connect

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -32,9 +32,7 @@ func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
 	return url
 }
 
-// ParseCookies parses an HTTP response and returns a string suitable for a Cookie header.
-func ParseCookies(resp *http.Response) string {
-	headers := resp.Header.Values("Set-Cookie")
+func parseCookies(headers []string) string {
 	cookies := make([]string, len(headers))
 
 	for i, cookie := range headers {
@@ -42,6 +40,11 @@ func ParseCookies(resp *http.Response) string {
 	}
 
 	return strings.Join(cookies, "; ")
+}
+
+// ParseCookies parses an HTTP response and returns a string suitable for a Cookie header.
+func ParseCookies(resp *http.Response) string {
+	return parseCookies(resp.Header.Values("Set-Cookie"))
 }
 
 // Go doesn't always like sending our exploit URI so use this raw version. SSL not implemented.

--- a/protocol/httphelper_test.go
+++ b/protocol/httphelper_test.go
@@ -1,0 +1,19 @@
+package protocol
+
+import (
+	"testing"
+)
+
+func TestParseCookies(t *testing.T) {
+	cookies := parseCookies([]string{
+		"cookie1=foo; path=/",
+		"cookie2=bar;",
+		"cookie3=baz",
+	})
+
+	if cookies != "cookie1=foo; cookie2=bar; cookie3=baz" {
+		t.Fatal(cookies)
+	}
+
+	t.Log(cookies)
+}


### PR DESCRIPTION
The `ParseCookies` function parses an HTTP response and returns a string suitable for a `Cookie` header.