### PR TITLE
Add Helper for Building Sane URI Path

### DIFF
--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -16,6 +16,7 @@ import (
 var GlobalUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" +
 	"(KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36 Edg/105.0.1343.33"
 
+// Returns a valid HTTP/HTTPS URL provided the given input.
 func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
 	url := ""
 	if ssl {
@@ -30,6 +31,19 @@ func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
 	url += uri
 
 	return url
+}
+
+// Using the variable amount of paths, return a URI without any extra '/'.
+func BuildURI(paths ...string) string {
+	uri := "/"
+	for _, path := range paths {
+		if !strings.HasSuffix(uri, "/") && !strings.HasPrefix(path, "/") {
+			uri += "/"
+		}
+		uri += path
+	}
+
+	return uri
 }
 
 func parseCookies(headers []string) string {

--- a/protocol/httphelper_test.go
+++ b/protocol/httphelper_test.go
@@ -17,3 +17,21 @@ func TestParseCookies(t *testing.T) {
 
 	t.Log(cookies)
 }
+
+func TestBuildURI(t *testing.T) {
+	uri := BuildURI("a", "file", "path")
+
+	if uri != "/a/file/path" {
+		t.Fatal(uri)
+	}
+
+	uri = BuildURI("a", "", "path")
+	if uri != "/a/path" {
+		t.Fatal(uri)
+	}
+
+	uri = BuildURI("")
+	if uri != "/" {
+		t.Fatal(uri)
+	}
+}


### PR DESCRIPTION
I found myself in a scenario where the user may or may not provide part of a URI and it was doing a really bad job adding and removing `/`. So I just created this function. Problem solved. You can do any of these:

```go
url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, protocol.BuildURI(globalEndpoint, "/app/"+webshellName))
```

```go
url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, protocol.BuildURI(globalEndpoint, "/app/", webshellName))
```

```go
url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, protocol.BuildURI(globalEndpoint, "app", webshellName))
```