### PR TITLE
Defining Rhosts by CIDR or File

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
+	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -11,25 +14,34 @@ import (
 	"github.com/vulncheck-oss/go-exploit/output"
 )
 
-func commonValidate(conf *config.Config, rhosts string, rports string) bool {
-	valid := true
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
 
-	switch {
-	case len(conf.Rhost) == 0 && len(rhosts) == 0:
-		valid = false
-		output.PrintError("Missing required option 'rhost' or 'rhosts'")
-	case conf.Rport == 0 && len(rports) == 0:
-		valid = false
-		output.PrintError("Missing required option 'rport' or 'rports'")
-	case !conf.DoVerify && !conf.DoVersionCheck && !conf.DoExploit:
-		valid = false
-		output.PrintError("Please provide an action (-v, -c, -e)")
-	case conf.SSL && conf.DetermineSSL:
-		valid = false
-		output.PrintError("-a and -s are mutually exclusive")
+func generateIPv4CIDR(cidr string) []string {
+	cidrSlice := make([]string, 0)
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		output.PrintError(err)
+
+		return cidrSlice
 	}
 
+	for ip := ip.Mask(ipNet.Mask); ipNet.Contains(ip); inc(ip) {
+		cidrSlice = append(cidrSlice, ip.String())
+	}
+
+	return cidrSlice
+}
+
+func buildRhosts(conf *config.Config, rhosts string, rports string) bool {
 	// convert the provided Rports to a slice of int
+	rportsSlice := make([]int, 0)
 	if len(rports) != 0 {
 		splitPorts := strings.Split(rports, ",")
 		for _, port := range splitPorts {
@@ -39,26 +51,155 @@ func commonValidate(conf *config.Config, rhosts string, rports string) bool {
 
 				return false
 			}
-			conf.Rports = append(conf.Rports, portInt)
+			rportsSlice = append(rportsSlice, portInt)
 		}
 	} else {
-		conf.Rports = append(conf.Rports, conf.Rport)
+		rportsSlice = append(rportsSlice, conf.Rport)
 	}
 
+	// convert the rhosts csv into a slice of strings
+	rhostsSlice := make([]string, 0)
 	if len(rhosts) != 0 {
 		splitRhosts := strings.Split(rhosts, ",")
-		conf.Rhosts = append(conf.Rhosts, splitRhosts...)
+		for _, host := range splitRhosts {
+			if strings.Contains(host, "/") {
+				rhostsSlice = append(rhostsSlice, generateIPv4CIDR(host)...)
+			} else {
+				rhostsSlice = append(rhostsSlice, host)
+			}
+		}
 	} else {
-		conf.Rhosts = append(conf.Rhosts, conf.Rhost)
+		rhostsSlice = append(rhostsSlice, conf.Rhost)
 	}
 
-	return valid
+	// determine the SSL status to assign everything
+	SSL := config.SSLDisabled
+	if conf.SSL {
+		SSL = config.SSLEnabled
+	} else if conf.DetermineSSL {
+		SSL = config.SSLAutodiscover
+	}
+
+	// convert rhostsSlice and rportsSlices to many RhostTriplet. Obviously
+	// this will consume a lot of memory if you provide a ton of ip/port combos
+	// so probably just don't do that ok? Like 1 million is probably fine, right?
+	// 1 billion, not so much.
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+	for iHost := range rhostsSlice {
+		for iPort := range rportsSlice {
+			triplet := config.RhostTriplet{
+				Rhost: rhostsSlice[iHost],
+				Rport: rportsSlice[iPort],
+				SSL:   SSL,
+			}
+			conf.RhostsNTuple = append(conf.RhostsNTuple, triplet)
+		}
+	}
+
+	return true
+}
+
+func parseRhostsFile(conf *config.Config, rhostsFile string) bool {
+	hostsFile, err := os.Open(rhostsFile)
+	if err != nil {
+		output.PrintError(err)
+
+		return false
+	}
+	defer hostsFile.Close()
+
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+	lineScan := bufio.NewScanner(hostsFile)
+	for lineScan.Scan() {
+		line := lineScan.Text()
+		splitTriplet := strings.Split(line, ",")
+		if len(splitTriplet) != 3 {
+			output.PrintfError("Invalid triplet: %s", line)
+
+			return false
+		}
+
+		portInt, err := strconv.Atoi(splitTriplet[1])
+		if err != nil {
+			output.PrintfError("Failed to convert the provided rport: %s", splitTriplet[1])
+
+			return false
+		}
+
+		// determine the SSL status to assign everything
+		SSL := config.SSLDisabled
+		if len(splitTriplet[2]) != 0 {
+			SSL = config.SSLEnabled
+		}
+
+		triplet := config.RhostTriplet{
+			Rhost: splitTriplet[0],
+			Rport: portInt,
+			SSL:   SSL,
+		}
+		conf.RhostsNTuple = append(conf.RhostsNTuple, triplet)
+	}
+
+	return true
+}
+
+func handleRhostsOptions(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
+	if len(rhostsFile) != 0 {
+		return parseRhostsFile(conf, rhostsFile)
+	}
+
+	return buildRhosts(conf, rhosts, rports)
+}
+
+func commonValidate(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
+	switch {
+	case len(conf.Rhost) == 0 && len(rhosts) == 0 && len(rhostsFile) == 0:
+		output.PrintError("Missing required option 'rhost', 'rhosts', or 'rhostsFile'")
+
+		return false
+	case conf.Rport == 0 && len(rports) == 0 && len(rhostsFile) == 0:
+		output.PrintError("Missing required option 'rport', 'rports', or 'rhostsFile'")
+
+		return false
+	case len(conf.Rhost) != 0 && len(rhosts) != 0:
+		output.PrintError("'rhost' and 'rhosts' are mutually exclusive")
+
+		return false
+	case len(conf.Rhost) != 0 && len(rhostsFile) != 0:
+		output.PrintError("'rhost' and 'rhosts-file' are mutually exclusive")
+
+		return false
+	case len(rhosts) != 0 && len(rhostsFile) != 0:
+		output.PrintError("'rhosts' and 'rhosts-file' are mutually exclusive")
+
+		return false
+	case !conf.DoVerify && !conf.DoVersionCheck && !conf.DoExploit:
+		output.PrintError("Please provide an action (-v, -c, -e)")
+
+		return false
+	case conf.SSL && conf.DetermineSSL:
+		output.PrintError("-a and -s are mutually exclusive")
+
+		return false
+	}
+
+	if len(rhostsFile) != 0 {
+		_, err := os.Stat(rhostsFile)
+		if err != nil {
+			output.PrintfError("Failed to stat %s: %s", rhostsFile, err)
+
+			return false
+		}
+	}
+
+	return true
 }
 
 // command line flags for defining the remote host.
-func remoteHostFlags(conf *config.Config, rhosts *string, rports *string) {
+func remoteHostFlags(conf *config.Config, rhosts *string, rhostsFile *string, rports *string) {
 	flag.StringVar(&conf.Rhost, "rhost", "", "The remote target's IP address")
 	flag.StringVar(rhosts, "rhosts", "", "A comma delimited list of remote target IP addresses")
+	flag.StringVar(rhostsFile, "rhosts-file", "", "A CSV containing a list of targets")
 	// the Rport should be pre-configured to have a default value (see config.go:New())
 	flag.IntVar(&conf.Rport, "rport", conf.Rport, "The remote target's server port")
 	flag.StringVar(rports, "rports", "", "A comma delimited list of the remote target's server ports")
@@ -86,9 +227,10 @@ func sslFlags(conf *config.Config) {
 // Parses the command line arguments used by RCE exploits.
 func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	var rhosts string
+	var rhostsFile string
 	var rports string
 
-	remoteHostFlags(conf, &rhosts, &rports)
+	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	sslFlags(conf)
@@ -126,8 +268,8 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
-	// validate command line arguments
-	success := commonValidate(conf, rhosts, rports)
+	// validate remaining command line arguments
+	success := commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
 
 	// validate a reverse shell or bind shell params are correctly specified
 	if conf.DoExploit {
@@ -164,9 +306,10 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 
 func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	var rhosts string
+	var rhostsFile string
 	var rports string
 
-	remoteHostFlags(conf, &rhosts, &rports)
+	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	sslFlags(conf)
@@ -184,15 +327,15 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
-	// validate command line arguments
-	return commonValidate(conf, rhosts, rports)
+	return commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
 }
 
 func WebShellCmdLineParse(conf *config.Config) bool {
 	var rhosts string
+	var rhostsFile string
 	var rports string
 
-	remoteHostFlags(conf, &rhosts, &rports)
+	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	sslFlags(conf)
@@ -210,6 +353,5 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
-	// validate command line arguments
-	return commonValidate(conf, rhosts, rports)
+	return commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
 }

--- a/cli/commandline_test.go
+++ b/cli/commandline_test.go
@@ -46,38 +46,98 @@ func TestCommonValidate(t *testing.T) {
 	conf := config.New(config.CodeExecution, []c2.Impl{c2.SimpleShellServer}, "test product", "CVE-2023-1270", 1270)
 	var rhosts string
 	var rports string
+	var rhostsFile string
 
-	if commonValidate(conf, rhosts, rports) {
+	if commonValidate(conf, rhosts, rports, rhostsFile) {
 		t.Fatal("commonValidate should fail with an empty Rhost")
 	}
 
 	conf.Rhost = "10.9.49.99"
-	if commonValidate(conf, rhosts, rports) {
+	if commonValidate(conf, rhosts, rports, rhostsFile) {
 		t.Fatal("commonValidate should fail with no supplied action")
 	}
 
 	conf.DoVerify = true
-	if !commonValidate(conf, rhosts, rports) {
+	if !commonValidate(conf, rhosts, rports, rhostsFile) {
 		t.Fatal("commonValidate should succeed with rhost, rport, and doVerify")
 	}
 
-	// clear rports
-	conf.Rports = make([]int, 0)
-	if !commonValidate(conf, rhosts, "1270,1280") {
+	conf.Rhost = ""
+	if !commonValidate(conf, "127.0.0.1", "1270,1280", rhostsFile) {
+		t.Fatal("commonValidate should have succeeded")
+	}
+
+	if !commonValidate(conf, "127.0.0.1,127.0.0.2", rports, rhostsFile) {
 		t.Fatal("commonValidate have succeeded")
 	}
+}
 
-	if len(conf.Rports) != 2 || conf.Rports[0] != 1270 || conf.Rports[1] != 1280 {
-		t.Fatalf("commonValidate didn't convert the port array correctly: %d %d %d", len(conf.Rports), conf.Rports[0], conf.Rports[1])
+func TestRhostsParsing(t *testing.T) {
+	conf := config.New(config.CodeExecution, []c2.Impl{c2.SimpleShellServer}, "test product", "CVE-2023-1270", 1270)
+
+	if !handleRhostsOptions(conf, "127.0.0.1,127.0.0.2", "80,443", "") {
+		t.Fatal("commonValidate should succeed")
+	}
+	if len(conf.RhostsNTuple) != 4 {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rhost != "127.0.0.1" || conf.RhostsNTuple[1].Rhost != "127.0.0.1" ||
+		conf.RhostsNTuple[2].Rhost != "127.0.0.2" || conf.RhostsNTuple[3].Rhost != "127.0.0.2" {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rport != 80 || conf.RhostsNTuple[1].Rport != 443 {
+		t.Fatal("Failed to parse rports")
+	}
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+
+	if !handleRhostsOptions(conf, "127.0.0.3", "443", "") {
+		t.Fatal("commonValidate should succeed")
+	}
+	if len(conf.RhostsNTuple) != 1 {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rhost != "127.0.0.3" {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rport != 443 {
+		t.Fatal("Failed to parse rports")
+	}
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+
+	conf.Rhost = "127.0.0.4"
+	if !handleRhostsOptions(conf, "", "443,80,8080", "") {
+		t.Fatal("commonValidate should succeed")
+	}
+	if len(conf.RhostsNTuple) != 3 {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rhost != "127.0.0.4" {
+		t.Fatal("Failed to parse rhosts")
+	}
+	if conf.RhostsNTuple[0].Rport != 443 {
+		t.Fatal("Failed to parse rports")
+	}
+	if conf.RhostsNTuple[1].Rport != 80 {
+		t.Fatal("Failed to parse rports")
+	}
+	if conf.RhostsNTuple[2].Rport != 8080 {
+		t.Fatal("Failed to parse rports")
+	}
+	conf.Rhost = ""
+
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+	if !handleRhostsOptions(conf, "192.168.1.0/24", "80", "") {
+		t.Fatal("commonValidate should succeed")
+	}
+	if len(conf.RhostsNTuple) != 256 {
+		t.Fatal("Failed to parse rhosts")
 	}
 
-	// clear rhosts
-	conf.Rhosts = make([]string, 0)
-	if !commonValidate(conf, "127.0.0.1,127.0.0.2", rports) {
-		t.Fatal("commonValidate have succeeded")
+	conf.RhostsNTuple = make([]config.RhostTriplet, 0)
+	if !handleRhostsOptions(conf, "192.168.1.0/24", "80,8080", "") {
+		t.Fatal("commonValidate should succeed")
 	}
-
-	if len(conf.Rhosts) != 2 || conf.Rhosts[0] != "127.0.0.1" || conf.Rhosts[1] != "127.0.0.2" {
-		t.Fatalf("commonValidate didn't convert the port array correctly: %d %s %s", len(conf.Rhosts), conf.Rhosts[0], conf.Rhosts[1])
+	if len(conf.RhostsNTuple) != 512 {
+		t.Fatal("Failed to parse rhosts")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,9 @@ type Config struct {
 
 	// the following are values configured by the user
 
-	// The target host, port, and SSL configuration - these will be the values operated on by the exploit
+	// target host, the target address/name the exploit will work on
 	Rhost string
+	// target port, the target port the exploit will work on
 	Rport int
 	// a list of specific targets
 	RhostsNTuple []RhostTriplet

--- a/config/config.go
+++ b/config/config.go
@@ -12,11 +12,26 @@ const (
 	Webshell              ExploitType = 2
 )
 
+type SSLSupport int
+
+const (
+	SSLDisabled     SSLSupport = 0
+	SSLEnabled      SSLSupport = 1
+	SSLAutodiscover SSLSupport = 2
+)
+
+type RhostTriplet struct {
+	Rhost string
+	Rport int
+	SSL   SSLSupport
+}
+
 // The config struct contains a mix of module specified configurations
 // and user specified configurations. The Config struct is first generated
 // by the exploit implementation and then modified by option parsing.
 type Config struct {
-	// values configured by the module
+	// the following are values configured by the exploit module
+
 	// the targeted product
 	Product string
 	// the CVE being tested
@@ -26,15 +41,13 @@ type Config struct {
 	// the c2 supported by the exploit
 	SupportedC2 []c2.Impl
 
-	// values configured by the user
-	// target host for remote exploits
+	// the following are values configured by the user
+
+	// The target host, port, and SSL configuration - these will be the values operated on by the exploit
 	Rhost string
-	// a list of target hosts
-	Rhosts []string
-	// target port
 	Rport int
-	// a list of target ports
-	Rports []int
+	// a list of specific targets
+	RhostsNTuple []RhostTriplet
 	// local host for remote exploits
 	Lhost string
 	// local port

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -1,8 +1,14 @@
 # Scanning Multiple Hosts
 
-`go-exploit` exploits can be used for scanning multiple hosts and ports. On the command line, exploits support `-rhosts` and `-rports`. At the time of writing, these are both comma delimited lists (although CIDR and file support should exist in the not too distant future).
+`go-exploit` exploits can be used for scanning multiple hosts and ports. This can be done three ways:
 
-The following example below scans multiple host/port combinations looking for Webmin targets:
+1. Providing a comma delimited list of IP addresses to `rhosts`.
+2. Same as 1 but also IP addresses using CIDR notation.
+3. Providing a file of hosts (ip,port,ssl) via `rhosts-file`.
+
+Examples follow:
+
+## Comma Delimited `rhosts` options
 
 ```sh
 albinolobster@mournland:~/go-exploit/examples/cve-2019-15107$ ./cve-2019-15107 -rhosts 10.9.49.174,10.9.49.205 -rports 80,10000 -a -v
@@ -24,3 +30,91 @@ albinolobster@mournland:~/go-exploit/examples/cve-2019-15107$ ./cve-2019-15107 -
 ```
 
 Note that `-a` is useful when using `rhosts` or `rports` because it will autodiscover if the target supports SSL.
+
+## CIDR Notation in `rhosts`
+
+```sh
+albinolobster@mournland:~/initial-access/feed/cve-2023-38646$ ./build/cve-2023-38646_linux-arm64 -v -rhosts 192.168.1.0/24 -rport 80
+[*] Starting target 0: 192.168.1.0:80
+[*] Validating the remote target is a Metabase installation
+[-] HTTP request error: Get "http://192.168.1.0:80/": dial tcp 192.168.1.0:80: connect: no route to host
+[-] The target isn't recognized as Metabase, quitting
+[*] Starting target 1: 192.168.1.1:80
+[*] Validating the remote target is a Metabase installation
+[-] Missing the Set-Cookie header
+[-] The target isn't recognized as Metabase, quitting
+[*] Starting target 2: 192.168.1.2:80
+[*] Validating the remote target is a Metabase installation
+[-] HTTP request error: Get "http://192.168.1.2:80/": dial tcp 192.168.1.2:80: connect: no route to host
+[-] The target isn't recognized as Metabase, quitting
+[*] Starting target 3: 192.168.1.3:80
+[*] Validating the remote target is a Metabase installation
+[-] HTTP request error: Get "http://192.168.1.3:80/": dial tcp 192.168.1.3:80: connect: no route to host
+[-] The target isn't recognized as Metabase, quitting
+[*] Starting target 4: 192.168.1.4:80
+[*] Validating the remote target is a Metabase installation
+[-] HTTP request error: Get "http://192.168.1.4:80/": dial tcp 192.168.1.4:80: connect: no route to host
+[-] The target isn't recognized as Metabase, quitting
+etc.
+```
+
+## Hosts Provided via `rhosts-file` (Shodan)
+
+The file format is supposed to be:
+
+```csv
+ip,port,<empty if no ssl | any text if ssl>
+ip,port,<empty if no ssl | any text if ssl>
+ip,port,<empty if no ssl | any text if ssl>
+```
+
+That might seem odd, but the goal here is two-fold:
+
+1. Support getting targets from Shodan.
+2. Support individual targets having SSL enabled or not.
+
+That works like the following (note that `-v` is just validation, e.g. checks that the target is openfire, no target was harmed):
+
+```sh
+albinolobster@mournland:~$ shodan count html:"jive-loginVersion"
+6549
+albinolobster@mournland:~$ shodan download openfire html:"jive-loginVersion"
+Search query:			html:jive-loginVersion
+Total number of results:	6549
+Query credits left:		9531
+Output file:			openfire.json.gz
+  [###################################-]   99%  00:00:00
+Saved 1000 results into file openfire.json.gz
+albinolobster@mournland:~$ shodan parse --fields ip_str,port,ssl.jarm --separator , openfire.json.gz > openfire.csv
+albinolobster@mournland:~$ tail openfire.csv
+51.222.136.154,9090,
+158.69.113.214,9091,07d14d16d21d21d07c07d14d07d21d9b2f5869a6985368a9dec764186a9175
+217.222.136.11,9090,
+201.245.189.172,9090,
+200.170.135.46,9090,
+74.84.138.186,9090,
+115.22.164.115,9090,
+192.99.169.243,9090,
+117.248.109.34,9090,
+208.180.74.57,9090,
+albinolobster@mournland:~$ ./build/cve-2023-32315_linux-arm64 -v -rhosts-file ./openfire.csv
+[*] Starting target 0: 202.39.62.186:9090
+[*] Validating the remote target is a Openfire installation
+[+] Target validation succeeded!
+[*] Starting target 1: 124.72.94.36:9090
+[*] Validating the remote target is a Openfire installation
+[+] Target validation succeeded!
+[*] Starting target 2: 103.82.30.158:9091
+[*] Validating the remote target is a Openfire installation
+[+] Target validation succeeded!
+[*] Starting target 3: 88.203.168.164:9091
+[*] Validating the remote target is a Openfire installation
+[+] Target validation succeeded!
+[*] Starting target 4: 41.77.78.157:9091
+[*] Validating the remote target is a Openfire installation
+[+] Target validation succeeded!
+[*] Starting target 5: 193.93.123.117:9091
+[*] Validating the remote target is a Openfire installation
+^C
+albinolobster@mournland:~$
+```

--- a/framework.go
+++ b/framework.go
@@ -191,7 +191,7 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 	// disable https cert verification globally
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	// if the c2 server is meant to catchs responses, initialize and start so it can bind
+	// if the c2 server is meant to catch responses, initialize and start so it can bind
 	startC2Server(conf)
 
 	// loop over all the provided host / port combos
@@ -211,7 +211,7 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 			conf.DetermineSSL = true
 		}
 
-		output.PrintfStatus("Starting target %d: %s:%d", index, conf.Rhost, conf.Rport)
+		output.PrintfStatus("Starting target %d: %s:%d [ssl:%t][autodiscover:%t]", index, conf.Rhost, conf.Rport, conf.SSL, conf.DetermineSSL)
 		if !doScan(sploit, conf) {
 			return
 		}

--- a/framework.go
+++ b/framework.go
@@ -191,22 +191,30 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 	// disable https cert verification globally
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	// if the c2 server catches responses, initialize and start so it can bind
+	// if the c2 server is meant to catchs responses, initialize and start so it can bind
 	startC2Server(conf)
 
 	// loop over all the provided host / port combos
-	hostIndex := 0
-	for _, host := range conf.Rhosts {
-		conf.Rhost = host
-		for _, port := range conf.Rports {
-			conf.Rport = port
-			output.PrintfStatus("Starting target %d: %s:%d", hostIndex, conf.Rhost, conf.Rport)
-
-			if !doScan(sploit, conf) {
-				return
-			}
-			globalWG.Wait()
-			hostIndex++
+	for index, host := range conf.RhostsNTuple {
+		// setup the conf for the downstream exploit
+		conf.Rhost = host.Rhost
+		conf.Rport = host.Rport
+		switch host.SSL {
+		case config.SSLDisabled:
+			conf.SSL = false
+			conf.DetermineSSL = false
+		case config.SSLEnabled:
+			conf.SSL = true
+			conf.DetermineSSL = false
+		case config.SSLAutodiscover:
+			conf.SSL = false
+			conf.DetermineSSL = true
 		}
+
+		output.PrintfStatus("Starting target %d: %s:%d", index, conf.Rhost, conf.Rport)
+		if !doScan(sploit, conf) {
+			return
+		}
+		globalWG.Wait()
 	}
 }


### PR DESCRIPTION
Added support for defining rhosts using CIDR notation and loading rhosts from a csv (for Shodan support).

For CIDR, that looks like this:

```sh
albinolobster@mournland:~/initial-access/feed/cve-2023-38646$ ./build/cve-2023-38646_linux-arm64 -v -rhosts 192.168.1.0/24 -rport 80
[*] Starting target 0: 192.168.1.0:80
[*] Validating the remote target is a Metabase installation
[-] HTTP request error: Get "http://192.168.1.0:80/": dial tcp 192.168.1.0:80: connect: no route to host
[-] The target isn't recognized as Metabase, quitting
[*] Starting target 1: 192.168.1.1:80
[*] Validating the remote target is a Metabase installation
[-] Missing the Set-Cookie header
[-] The target isn't recognized as Metabase, quitting
[*] Starting target 2: 192.168.1.2:80
[*] Validating the remote target is a Metabase installation
[-] HTTP request error: Get "http://192.168.1.2:80/": dial tcp 192.168.1.2:80: connect: no route to host
[-] The target isn't recognized as Metabase, quitting
[*] Starting target 3: 192.168.1.3:80
[*] Validating the remote target is a Metabase installation
[-] HTTP request error: Get "http://192.168.1.3:80/": dial tcp 192.168.1.3:80: connect: no route to host
[-] The target isn't recognized as Metabase, quitting
[*] Starting target 4: 192.168.1.4:80
[*] Validating the remote target is a Metabase installation
[-] HTTP request error: Get "http://192.168.1.4:80/": dial tcp 192.168.1.4:80: connect: no route to host
[-] The target isn't recognized as Metabase, quitting
etc.
```

File loading is a little more involved, although for good reason. The file format is supposed to be:

```csv
ip,port,<empty if no ssl | any text if ssl>
ip,port,<empty if no ssl | any text if ssl>
ip,port,<empty if no ssl | any text if ssl>
```

That might seem odd, but the goal here is two-fold:
1. Support getting targets from Shodan.
2. Support individual targets having SSL enabled or not.

That works like the following (note that `-v` is just validation, e.g. checks that the target is openfire, no target was harmed):

```sh
albinolobster@mournland:~$ shodan count html:"jive-loginVersion"
6549
albinolobster@mournland:~$ shodan download openfire html:"jive-loginVersion"
Search query:			html:jive-loginVersion
Total number of results:	6549
Query credits left:		9531
Output file:			openfire.json.gz
  [###################################-]   99%  00:00:00
Saved 1000 results into file openfire.json.gz
albinolobster@mournland:~$ shodan parse --fields ip_str,port,ssl.jarm --separator , openfire.json.gz > openfire.csv
albinolobster@mournland:~$ tail openfire.csv 
51.222.136.154,9090,
158.69.113.214,9091,07d14d16d21d21d07c07d14d07d21d9b2f5869a6985368a9dec764186a9175
217.222.136.11,9090,
201.245.189.172,9090,
200.170.135.46,9090,
74.84.138.186,9090,
115.22.164.115,9090,
192.99.169.243,9090,
117.248.109.34,9090,
208.180.74.57,9090,
albinolobster@mournland:~$ ./build/cve-2023-32315_linux-arm64 -v -rhosts-file ./openfire.csv 
[*] Starting target 0: 202.39.62.186:9090
[*] Validating the remote target is a Openfire installation
[+] Target validation succeeded!
[*] Starting target 1: 124.72.94.36:9090
[*] Validating the remote target is a Openfire installation
[+] Target validation succeeded!
[*] Starting target 2: 103.82.30.158:9091
[*] Validating the remote target is a Openfire installation
[+] Target validation succeeded!
[*] Starting target 3: 88.203.168.164:9091
[*] Validating the remote target is a Openfire installation
[+] Target validation succeeded!
[*] Starting target 4: 41.77.78.157:9091
[*] Validating the remote target is a Openfire installation
[+] Target validation succeeded!
[*] Starting target 5: 193.93.123.117:9091
[*] Validating the remote target is a Openfire installation
^C
albinolobster@mournland:~$
```