### PR TITLE
Added -proxy command line option for http/https/tcp connections

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -195,6 +195,23 @@ func commonValidate(conf *config.Config, rhosts string, rports string, rhostsFil
 	return true
 }
 
+// command line options for proxying.
+func proxyFlags(proxy *string) {
+	flag.StringVar(proxy, "proxy", "", "A proxy that will be used for all communication")
+}
+
+// Go can automatically handle HTTP proxying (if HTTP_PROXY env is set) and it can automatically
+// handle HTTPS proxying (if HTTPS_PROXY env is set). It can't handle normal tcp socket proxying
+// though, so we'll set ALL_PROXY for that (and handle the logic in protocol/tcpsocket.go).
+func handleProxyOptions(proxy string) {
+	if len(proxy) == 0 {
+		return
+	}
+	os.Setenv("HTTP_PROXY", proxy)
+	os.Setenv("HTTPS_PROXY", proxy)
+	os.Setenv("ALL_PROXY", proxy)
+}
+
 // command line options for logging.
 func loggingFlags(logFile *string, frameworkLogLevel *string, exploitLogLevel *string) {
 	flag.BoolVar(&output.FormatJSON, "log-json", false, "Indicates if logging should use JSON")
@@ -270,7 +287,9 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	var logFile string
 	var frameworkLogLevel string
 	var exploitLogLevel string
+	var proxy string
 
+	proxyFlags(&proxy)
 	loggingFlags(&logFile, &frameworkLogLevel, &exploitLogLevel)
 	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
@@ -309,6 +328,8 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	handleProxyOptions(proxy)
 
 	// validate remaining command line arguments
 	success := handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
@@ -354,7 +375,9 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	var logFile string
 	var frameworkLogLevel string
 	var exploitLogLevel string
+	var proxy string
 
+	proxyFlags(&proxy)
 	loggingFlags(&logFile, &frameworkLogLevel, &exploitLogLevel)
 	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
@@ -374,6 +397,8 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
+	handleProxyOptions(proxy)
+
 	return handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
 		commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
 }
@@ -385,7 +410,9 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 	var logFile string
 	var frameworkLogLevel string
 	var exploitLogLevel string
+	var proxy string
 
+	proxyFlags(&proxy)
 	loggingFlags(&logFile, &frameworkLogLevel, &exploitLogLevel)
 	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
 	localHostFlags(conf)
@@ -404,6 +431,8 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 		fmt.Println("\t./exploit -v -c -e -a -rhost 10.12.70.247 -rport 443")
 	}
 	flag.Parse()
+
+	handleProxyOptions(proxy)
 
 	return handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
 		commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)

--- a/framework.go
+++ b/framework.go
@@ -41,9 +41,7 @@ package exploit
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -51,6 +49,7 @@ import (
 	"github.com/vulncheck-oss/go-exploit/cli"
 	"github.com/vulncheck-oss/go-exploit/config"
 	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
 )
 
 // The return type for CheckVersion().
@@ -204,23 +203,21 @@ func doVersionCheck(sploit Exploit, conf *config.Config) bool {
 	return true
 }
 
-// connects to the remote server and tries to determine if the server expects SSL comms
-// this is accomplished by attempting to read 5 bytes from the server and timing out
-// if it fails. This is a fair amount of overhead if done at scale, but reasonable for
-// someone that is using -a (instead of -s or nothing). This should only be slow on
-// non-ssl connections...
+// Automatically determine if the remote target is using SSL or not. This *does* work
+// even if a proxy is configured. This can be slow when dealing with non-SSL
+// targets that don't respond to the handshake attempt, but it seems a reasonable trade-off.
 func determineServerSSL(rhost string, rport int) bool {
-	conf := &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", rhost+":"+strconv.Itoa(rport), conf)
-	if err != nil {
+	conn, ok := protocol.TCPConnect(rhost, rport)
+	if !ok {
 		return false
 	}
-	conn.Close()
+	defer conn.Close()
 
-	return true
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	_ = tlsConn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	err := tlsConn.Handshake()
+
+	return err == nil
 }
 
 // Invokes command line parsing based on the type of exploit that was implemented.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3
 	github.com/vjeantet/ldapserver v1.0.1
-	golang.org/x/crypto v0.11.0
-	golang.org/x/text v0.11.0
+	golang.org/x/crypto v0.12.0
+	golang.org/x/net v0.10.0
+	golang.org/x/text v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,9 @@ github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3 h1:wIONC+HMNRqmWBjuM
 github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3/go.mod h1:37YR9jabpiIxsb8X9VCIx8qFOjTDIIrIHHODa8C4gz0=
 github.com/vjeantet/ldapserver v1.0.1 h1:3z+TCXhwwDLJC3pZCNbuECPDqC2x1R7qQQbswB1Qwoc=
 github.com/vjeantet/ldapserver v1.0.1/go.mod h1:YvUqhu5vYhmbcLReMLrm/Tq3S7Yj43kSVFvvol6Lh6k=
-golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
-golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
+golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/protocol/tcpsocket.go
+++ b/protocol/tcpsocket.go
@@ -46,7 +46,7 @@ func TCPConnect(host string, port int) (net.Conn, bool) {
 
 		conn, err := dialer.Dial("tcp", target)
 		if err != nil {
-			output.PrintFrameworkError("Connection failed: " + err.Error())
+			output.PrintfFrameworkError("Connection failed: %s", err.Error())
 
 			return nil, false
 		}

--- a/protocol/tcpsocket.go
+++ b/protocol/tcpsocket.go
@@ -4,8 +4,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 
 	"github.com/vulncheck-oss/go-exploit/output"
+	"golang.org/x/net/proxy"
 )
 
 // Connections to the remote target with or without encryption depending on the ssl bool.
@@ -30,14 +33,29 @@ func TLSConnect(host string, port int) (net.Conn, bool) {
 // Connects to a remote target without encryption.
 func TCPConnect(host string, port int) (net.Conn, bool) {
 	target := fmt.Sprintf("%s:%d", host, port)
-	tcpAddr, err := net.ResolveTCPAddr("tcp", target)
-	if err != nil {
-		output.PrintFrameworkError("ResolveTCPAddr failed: " + err.Error())
 
-		return nil, false
+	// do we need to use a proxy?
+	envProxy := os.Getenv("ALL_PROXY")
+	if strings.HasPrefix(envProxy, "socks5://") {
+		dialer, err := proxy.SOCKS5("tcp", envProxy[len("socks5://"):], nil, proxy.Direct)
+		if err != nil {
+			output.PrintfFrameworkError("SOCKS5 error: %s", err.Error())
+
+			return nil, false
+		}
+
+		conn, err := dialer.Dial("tcp", target)
+		if err != nil {
+			output.PrintFrameworkError("Connection failed: " + err.Error())
+
+			return nil, false
+		}
+
+		return conn, true
 	}
 
-	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	// no proxy involved
+	conn, err := net.Dial("tcp", target)
 	if err != nil {
 		output.PrintFrameworkError("Connection failed: " + err.Error())
 


### PR DESCRIPTION
Proxying with TCPConnect, TLSConnect, MixedConnect all assume a socks5:// proxy is configured. Not providing a socks5:// address will cause them to directly connect to the target.

The automatic ssl detection (`-a` on the command line) also assumes a socks5:// proxy.

Using an http or https proxy is also fine, but don't expect the above to use them properly (as they are not http/https connections).