### PR TITLE
Fixed shells. Unified code. Made bind shell proxy aware.

### DIFF
--- a/c2/cli/basic.go
+++ b/c2/cli/basic.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
+)
+
+// A very basic reverse/bind shell handler.
+func Basic(conn net.Conn) {
+	// Create channels for communication between goroutines.
+	responseCh := make(chan string)
+	quit := make(chan struct{})
+
+	// Use a WaitGroup to wait for goroutines to finish.
+	var wg sync.WaitGroup
+
+	// Goroutine to read responses from the server.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		responseBuffer := make([]byte, 1024)
+		for {
+			select {
+			case <-quit:
+				return
+			default:
+				_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+				bytesRead, err := conn.Read(responseBuffer)
+				if err != nil && !strings.Contains(err.Error(), "i/o timeout") {
+					// things have gone sideways, but the command line won't know that
+					// until they attempt to execute a command and the socket fails.
+					// i think that's largely okay.
+					return
+				}
+				if bytesRead > 0 {
+					// I think there is technically a race condition here where the socket
+					// could have move data to write, but the user has already called exit
+					// below. I that that's tolerable for now.
+					responseCh <- string(responseBuffer[:bytesRead])
+				}
+			}
+		}
+	}()
+
+	// Goroutine to handle responses and print them.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for response := range responseCh {
+			select {
+			case <-quit:
+				return
+			default:
+				output.PrintShell(response)
+			}
+		}
+	}()
+
+	for {
+		// read user input until they type 'exit\n' or the socket breaks
+		// note that ReadString is blocking, so they won't know the socket
+		// is broken until they attempt to write something
+		reader := bufio.NewReader(os.Stdin)
+		command, _ := reader.ReadString('\n')
+		ok := protocol.TCPWrite(conn, []byte(command))
+		if !ok || command == "exit\n" {
+			break
+		}
+	}
+
+	// signal for everyone to shutdown
+	quit <- struct{}{}
+	close(responseCh)
+
+	// wait until the go routines are clean up
+	wg.Wait()
+}

--- a/c2/simpleshell/simpleshellclient.go
+++ b/c2/simpleshell/simpleshellclient.go
@@ -1,14 +1,12 @@
 package simpleshell
 
 import (
-	"bufio"
 	"net"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/vulncheck-oss/go-exploit/c2/cli"
 	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
 )
 
 type Client struct {
@@ -39,6 +37,12 @@ func (shellClient *Client) Init(ipAddr string, port int, isClient bool) bool {
 		return false
 	}
 
+	if port == 0 {
+		output.PrintFrameworkError("Provided an invalid bind port.")
+
+		return false
+	}
+
 	return true
 }
 
@@ -47,63 +51,31 @@ func (shellClient *Client) Run(timeout int) {
 	if !ok {
 		return
 	}
+	// close the connection when the shell is complete
+	defer conn.Close()
 
-	for {
-		buffReader := bufio.NewReader(conn)
-		for {
-			for {
-				// read until the timeout hits
-				err := conn.SetReadDeadline(time.Now().Add(1 * time.Second))
-				if err != nil {
-					conn.Close()
-					output.PrintFrameworkError("Shell terminated")
+	output.PrintfFrameworkStatus("Active shell on %s:%d", shellClient.ConnectAddr, shellClient.ConnectPort)
 
-					return
-				}
-				line, err := buffReader.ReadBytes('\n')
-				if err != nil {
-					if !strings.Contains(err.Error(), "i/o timeout") {
-						conn.Close()
-						output.PrintFrameworkError("Shell terminated")
+	cli.Basic(conn)
 
-						return
-					}
-
-					break
-				}
-				output.PrintShell(string(line))
-			}
-
-			output.PrintShell("$ ")
-			reader := bufio.NewReader(os.Stdin)
-			userInput, _ := reader.ReadString('\n')
-			_, writeErr := conn.Write([]byte(userInput))
-			if writeErr != nil {
-				conn.Close()
-				output.PrintFrameworkError("Shell terminated")
-
-				return
-			}
-		}
-	}
+	// we done here
+	output.PrintfFrameworkStatus("Connection closed")
 }
 
-func connect(ipAddr string, port int, timeout int) (net.Conn, bool) {
-	// loop for 30 seconds trying to make the connection
-	for i := 0; true; i += 3 {
-		conn, err := net.Dial("tcp", ipAddr+":"+strconv.Itoa(port))
-		if err != nil {
-			if i > timeout {
-				output.PrintFrameworkError("Could not connect to the remote host: " + err.Error())
-
-				return nil, false
-			}
-			time.Sleep(3 * time.Second)
-		} else {
-			output.PrintfFrameworkSuccess("Connected to %s:%d!", ipAddr, port)
+func connect(host string, port int, timeout int) (net.Conn, bool) {
+	// loop every three seconds until timeout
+	for i := 0; i < timeout; i += 3 {
+		// TCPConnect is proxy aware, so it will use the proxy if configured
+		conn, ok := protocol.TCPConnect(host, port)
+		if ok {
+			output.PrintfFrameworkSuccess("Connected to %s:%d!", host, port)
 
 			return conn, true
 		}
+		// this is technically not correct. TCPConnect itself has a 10 second timeout. If the server doesn't
+		// send a RST when we try to connect then we'll wait the full 10 + this 3 for a full 13... which means
+		// we won't honor the timeout correctly.
+		time.Sleep(3 * time.Second)
 	}
 
 	return nil, false

--- a/c2/simpleshell/simpleshellserver.go
+++ b/c2/simpleshell/simpleshellserver.go
@@ -1,14 +1,13 @@
 package simpleshell
 
 import (
-	"bufio"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/vulncheck-oss/go-exploit/c2/cli"
 	"github.com/vulncheck-oss/go-exploit/output"
 )
 
@@ -91,47 +90,20 @@ func (shellServer *Server) Run(timeout int) {
 	}
 }
 
-func handleSimpleConn(client net.Conn, cliLock *sync.Mutex, remoteAddr net.Addr) {
+func handleSimpleConn(conn net.Conn, cliLock *sync.Mutex, remoteAddr net.Addr) {
 	// connections will stack up here. Currently that will mean a race
 	// to the next connection but we can add in attacker handling of
 	// connections latter
 	cliLock.Lock()
 	defer cliLock.Unlock()
 
-	output.PrintfFrameworkSuccess("Active shell from %v", remoteAddr)
-	buffReader := bufio.NewReader(client)
-	for {
-		// give the user a prompt and ask them for input
-		output.PrintShell("$ ")
-		reader := bufio.NewReader(os.Stdin)
-		userInput, _ := reader.ReadString('\n')
-		_, writeError := client.Write([]byte(userInput))
-		if writeError != nil {
-			goto cleanup
-		}
+	// close the connection when the shell is complete
+	defer conn.Close()
 
-		// this shell expect some type of response. give a high timeout on the
-		// first read and a tight timeout on the remaining.
-		wait := 10000
-		for {
-			err := client.SetReadDeadline(time.Now().Add(time.Duration(wait) * time.Millisecond))
-			if err != nil {
-				goto cleanup
-			}
-			line, err := buffReader.ReadBytes('\n')
-			if err != nil {
-				if !strings.Contains(err.Error(), "i/o timeout") {
-					goto cleanup
-				}
+	output.PrintfFrameworkStatus("Active shell from %v", remoteAddr)
 
-				break
-			}
-			output.PrintShell(string(line))
-			wait = 100
-		}
-	}
+	cli.Basic(conn)
 
-cleanup:
-	client.Close()
-	output.PrintfFrameworkStatus("Shell from %v terminated", remoteAddr)
+	// we done here
+	output.PrintfFrameworkStatus("Connection closed %v", remoteAddr)
 }

--- a/c2/sslshell/sslshellserver.go
+++ b/c2/sslshell/sslshellserver.go
@@ -17,7 +17,6 @@
 package sslshell
 
 import (
-	"bufio"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -27,11 +26,11 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/vulncheck-oss/go-exploit/c2/cli"
 	"github.com/vulncheck-oss/go-exploit/output"
 	"github.com/vulncheck-oss/go-exploit/random"
 )
@@ -169,47 +168,20 @@ func generateCertificate() (tls.Certificate, bool) {
 	return certificate, true
 }
 
-func handleSimpleConn(client net.Conn, cliLock *sync.Mutex, remoteAddr net.Addr) {
+func handleSimpleConn(conn net.Conn, cliLock *sync.Mutex, remoteAddr net.Addr) {
 	// connections will stack up here. Currently that will mean a race
 	// to the next connection but we can add in attacker handling of
 	// connections latter
 	cliLock.Lock()
 	defer cliLock.Unlock()
 
+	// close the connection when the shell is complete
+	defer conn.Close()
+
 	output.PrintfFrameworkStatus("Active shell from %v", remoteAddr)
-	buffReader := bufio.NewReader(client)
-	for {
-		// give the user a prompt and ask them for input
-		output.PrintShell("$ ")
-		reader := bufio.NewReader(os.Stdin)
-		userInput, _ := reader.ReadString('\n')
-		_, writeError := client.Write([]byte(userInput))
-		if writeError != nil {
-			goto cleanup
-		}
 
-		// this shell expect some type of response. give a high timeout on the
-		// first read and a tight timeout on the remaining.
-		wait := 10000
-		for {
-			err := client.SetReadDeadline(time.Now().Add(time.Duration(wait) * time.Millisecond))
-			if err != nil {
-				goto cleanup
-			}
-			line, err := buffReader.ReadBytes('\n')
-			if err != nil {
-				if !strings.Contains(err.Error(), "i/o timeout") {
-					goto cleanup
-				}
+	cli.Basic(conn)
 
-				break
-			}
-			output.PrintShell(string(line))
-			wait = 100
-		}
-	}
-
-cleanup:
-	client.Close()
-	output.PrintfFrameworkStatus("Shell from %v terminated", remoteAddr)
+	// we done here
+	output.PrintfFrameworkStatus("Connection closed %v", remoteAddr)
 }

--- a/framework.go
+++ b/framework.go
@@ -206,7 +206,7 @@ func doVersionCheck(sploit Exploit, conf *config.Config) bool {
 // Automatically determine if the remote target is using SSL or not. This *does* work
 // even if a proxy is configured. This can be slow when dealing with non-SSL
 // targets that don't respond to the handshake attempt, but it seems a reasonable trade-off.
-// return bool (connected), bool (ssl)
+// return bool (connected), bool (ssl).
 func determineServerSSL(rhost string, rport int) (bool, bool) {
 	conn, ok := protocol.TCPConnect(rhost, rport)
 	if !ok {
@@ -237,16 +237,16 @@ func parseCommandLine(conf *config.Config) bool {
 	}
 }
 
-func startC2Server(conf *config.Config) {
+func startC2Server(conf *config.Config) bool {
 	if conf.DoExploit && conf.ExType == config.CodeExecution && !conf.ThirdPartyC2Server && conf.Bport == 0 {
 		c2Impl, success := c2.GetInstance(conf.C2Type)
 		if !success || c2Impl == nil {
-			return
+			return false
 		}
 
 		success = c2Impl.Init(conf.Lhost, conf.Lport, false)
 		if !success {
-			return
+			return false
 		}
 
 		globalWG.Add(1)
@@ -256,6 +256,8 @@ func startC2Server(conf *config.Config) {
 			output.PrintFrameworkStatus("C2 server exited")
 		}()
 	}
+
+	return true
 }
 
 // execute verify, version check, and exploit. Return false if an unrecoverable error occurred.
@@ -333,7 +335,9 @@ func RunProgram(sploit Exploit, conf *config.Config) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	// if the c2 server is meant to catch responses, initialize and start so it can bind
-	startC2Server(conf)
+	if !startC2Server(conf) {
+		return
+	}
 
 	// loop over all the provided host / port combos
 	for index, host := range conf.RhostsNTuple {


### PR DESCRIPTION
@wvu had noticed oddness with the openssl shell. Additionally, sending an empty command resulted in a 10 second hang. Also, the tear down code was working oddly. And somehow we had three implementations across the three shells.

NOT ANYMORE

This combines the shell logic into one spot, and removes all the old issues. I think there are probably two annoying things:

- I removed the shell prompt ('$') so you might just a blank line depending on how you establish your shell.
- To make the bindshell proxy aware, I used `TCPConnect` (which is always proxy aware). But it also logs failed connections. So you'll likely get error messages on the first couple of attempts. In an ideal world the bindshell would start until the exploit has been thrown but that plumbing doesn't exist.