### PR TITLE
Added an artificial cap to the size of RocketMQ messages

### DIFF
--- a/protocol/rocketmq/remoting.go
+++ b/protocol/rocketmq/remoting.go
@@ -21,6 +21,13 @@ import (
 // The code can be found here:
 // https://github.com/apache/rocketmq/blob/c78061bf6ca5f35452510ec4107c46735c51c316/test/src/test/resources/schema/protocol/common.protocol.RequestCode.schema
 func CreateMqRemotingMessage(payload string, code int, version int) []byte {
+	// Check the payload isn't overly large. I don't really see a scenario where 16 million bytes is
+	// needed. Heck, I don't see needing more than 1k for the current exploitation use case.
+	if len(payload) > 2^24 {
+		output.PrintFrameworkError("Payload size exceeded artifical cap.")
+
+		return nil
+	}
 	mqHeader := map[string]any{
 		"code":                    code,
 		"flag":                    0,

--- a/protocol/rocketmq/remoting.go
+++ b/protocol/rocketmq/remoting.go
@@ -20,6 +20,8 @@ import (
 //
 // The code can be found here:
 // https://github.com/apache/rocketmq/blob/c78061bf6ca5f35452510ec4107c46735c51c316/test/src/test/resources/schema/protocol/common.protocol.RequestCode.schema
+//
+// This can return 'nil' if the requested payload is too large or marshalling the json header fails
 func CreateMqRemotingMessage(payload string, code int, version int) []byte {
 	// Check the payload isn't overly large. I don't really see a scenario where 16 million bytes is
 	// needed. Heck, I don't see needing more than 1k for the current exploitation use case.

--- a/protocol/rocketmq/remoting_test.go
+++ b/protocol/rocketmq/remoting_test.go
@@ -1,0 +1,20 @@
+package rocketmq
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_MaxSize(t *testing.T) {
+	msg := strings.Repeat("A", 2^24+1)
+	mqMsg := CreateMqRemotingMessage(msg, 112, 1)
+	if mqMsg != nil {
+		t.Error("msg size should have exceeded artifical cap")
+	}
+
+	msg = strings.Repeat("A", 2^24)
+	mqMsg = CreateMqRemotingMessage(msg, 112, 1)
+	if mqMsg == nil {
+		t.Error("msg size should not have exceeded the artifical cap")
+	}
+}


### PR DESCRIPTION
See #62 

I don't see any scenario in which someone sends a full 2^32-1 makes any sense (unless it's for denial of service reasons, I guess but I'm not incredibly excited about supporting that case). I opted to just put a cap at 2^24. Which might be lazy, but I think reasonable for our use case.