### PR TITLE
Fixed ipv6 HTTP bug. See #68

### DIFF
--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -24,6 +25,12 @@ func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
 		url += "https://"
 	} else {
 		url += "http://"
+	}
+
+	// is the address v6?
+	ip := net.ParseIP(rhost)
+	if ip != nil && ip.To4() == nil {
+		rhost = "[" + rhost + "]"
 	}
 
 	url += rhost
@@ -68,6 +75,12 @@ func DoRawHTTPRequest(rhost string, rport int, uri string, verb string) bool {
 	conn, success := TCPConnect(rhost, rport)
 	if !success {
 		return false
+	}
+
+	// is the address v6?
+	ip := net.ParseIP(rhost)
+	if ip != nil && ip.To4() == nil {
+		rhost = "[" + rhost + "]"
 	}
 
 	httpRequest := verb + " " + uri + " HTTP/1.1\r\n"

--- a/protocol/httphelper_test.go
+++ b/protocol/httphelper_test.go
@@ -35,3 +35,18 @@ func TestBuildURI(t *testing.T) {
 		t.Fatal(uri)
 	}
 }
+
+func TestGenerateURL(t *testing.T) {
+	uri := GenerateURL("google.com", 443, true, "/")
+	if uri != "https://google.com:443/" {
+		t.Fatal(uri)
+	}
+	uri = GenerateURL("google.com", 443, true, "/helloworld")
+	if uri != "https://google.com:443/helloworld" {
+		t.Fatal(uri)
+	}
+	uri = GenerateURL("::1", 1270, false, "/")
+	if uri != "http://[::1]:1270/" {
+		t.Fatal(uri)
+	}
+}


### PR DESCRIPTION
Before:
![broken](https://github.com/vulncheck-oss/go-exploit/assets/113205286/b378bcee-258c-483c-8a14-2f2463ba408f)

After:

![probably-fixed](https://github.com/vulncheck-oss/go-exploit/assets/113205286/0945d79b-3b42-4f6d-86a7-4bda75df00cc)
