### PR TITLE
Enable dupword linter; fix or disable found issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     #- depguard
     - dogsled
     - durationcheck
+    - dupword
     - errchkjson
     - errname
     - errorlint

--- a/framework.go
+++ b/framework.go
@@ -262,7 +262,7 @@ func startC2Server(conf *config.Config) bool {
 
 // execute verify, version check, and exploit. Return false if an unrecoverable error occurred.
 func doScan(sploit Exploit, conf *config.Config) bool {
-	// autodetect if the the target is using SSL or not
+	// autodetect if the target is using SSL or not
 	if conf.DetermineSSL {
 		connected, sslEnabled := determineServerSSL(conf.Rhost, conf.Rport)
 		if !connected {

--- a/java/javagadget.go
+++ b/java/javagadget.go
@@ -14,6 +14,8 @@ import (
 //
 // The gadget works on both Windows and Linux and will automatically detect the platform
 // and tool to use for executing commands (cmd.exe or /bin/bash).
+//
+//nolint:dupword // Duplicate words () found
 func CreateBeanutilsReverseShell(lhost string, lport int) string {
 	gadget := "\xac\xed\x00\x05\x73\x72\x00\x17\x6a\x61\x76\x61\x2e\x75\x74\x69" +
 		"\x6c\x2e\x50\x72\x69\x6f\x72\x69\x74\x79\x51\x75\x65\x75\x65\x94" +

--- a/java/ldapjndi/ldapjndi.go
+++ b/java/ldapjndi/ldapjndi.go
@@ -421,6 +421,7 @@ func createBeanUtils194GenericBash(command string) string {
 	encodedCommand += strings.Repeat("a", 207-len(encodedCommand))
 	encodedCommand += "}"
 
+	//nolint:dupword // Duplicate words () found
 	complete := "\xac\xed" +
 		"\x00\x05\x73\x72\x00\x17\x6a\x61\x76\x61\x2e\x75\x74\x69\x6c\x2e" +
 		"\x50\x72\x69\x6f\x72\x69\x74\x79\x51\x75\x65\x75\x65\x94\xda\x30" +
@@ -615,6 +616,7 @@ func createHTTPReverseShell(lhost string, lport int, classname string) string {
 	commandLength := make([]byte, 2)
 	binary.BigEndian.PutUint16(commandLength, uint16(len(command)))
 
+	//nolint:dupword // Duplicate words () found
 	complete := "\xca\xfe\xba\xbe\x00\x00\x00\x32\x00\x48\x01" +
 		string(classLength) + classname +
 		"\x07\x00" +


### PR DESCRIPTION
This PR enables [`dupword`](https://github.com/Abirdcfly/dupword) linter. And fixes one `dupword` issue in the comment.