### PR TITLE
Enable non-default gocritic checks; fix found issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,8 +84,20 @@ linters:
 
 
 linters-settings:
-    lll:
-      line-length: 140
+  gocritic:
+    # Enable multiple checks by tags. See "Tags" section in https://github.com/go-critic/go-critic#usage.
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - emptyFallthrough
+      - importShadow
+      - unnamedResult
+  lll:
+    line-length: 140
 issues:
   exclude-rules:
     - path: c2/sslshell/sslshellserver.go

--- a/c2/factory_test.go
+++ b/c2/factory_test.go
@@ -27,7 +27,7 @@ func TestHTTPServeFileInit(t *testing.T) {
 	}
 
 	// random name should have been generated
-	if len(httpservefile.GetInstance().HostedFiles["factory.go"].RandomName) != 0 {
+	if httpservefile.GetInstance().HostedFiles["factory.go"].RandomName != "" {
 		t.Fatal("Instance did not generate a random filename")
 	}
 	if httpservefile.GetInstance().HTTPAddr != "127.0.0.1" {

--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -95,7 +95,7 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 	httpServer.HTTPAddr = rhostAddr
 	httpServer.HTTPPort = rhostPort
 
-	if len(httpServer.FilesToServe) == 0 {
+	if httpServer.FilesToServe == "" {
 		output.PrintFrameworkError("Provide an httpServeFile.FilesToServe option on the command line")
 
 		return false
@@ -137,7 +137,7 @@ func (httpServer *Server) Init(rhostAddr string, rhostPort int, isClient bool) b
 	if httpServer.TLS {
 		var ok bool
 		var err error
-		if len(httpServer.CertificateFile) != 0 && len(httpServer.PrivateKeyFile) != 0 {
+		if httpServer.CertificateFile != "" && httpServer.PrivateKeyFile != "" {
 			httpServer.Certificate, err = tls.LoadX509KeyPair(httpServer.CertificateFile, httpServer.PrivateKeyFile)
 			if err != nil {
 				output.PrintfFrameworkError("Error loading certificate: %s", err.Error())
@@ -209,7 +209,7 @@ func (httpServer *Server) Run(timeout int) {
 
 // Returns the random name of the provided filename. If filename is empty, return the first entry.
 func (httpServer *Server) GetRandomName(filename string) string {
-	if len(filename) == 0 {
+	if filename == "" {
 		for _, hosted := range httpServer.HostedFiles {
 			return hosted.RandomName
 		}

--- a/c2/httpserveshell/httpserveshell.go
+++ b/c2/httpserveshell/httpserveshell.go
@@ -74,7 +74,7 @@ func (serveShell *Server) CreateFlags() {
 
 // load the provided file into memory. Generate the random filename.
 func (serveShell *Server) Init(rhost string, rport int, isClient bool) bool {
-	if len(serveShell.HTTPAddr) == 0 {
+	if serveShell.HTTPAddr == "" {
 		output.PrintFrameworkError("User must specify -httpServeFile.BindAddr")
 
 		return false

--- a/c2/simpleshell/simpleshellclient.go
+++ b/c2/simpleshell/simpleshellclient.go
@@ -62,7 +62,7 @@ func (shellClient *Client) Run(timeout int) {
 	output.PrintfFrameworkStatus("Connection closed")
 }
 
-func connect(host string, port int, timeout int) (net.Conn, bool) {
+func connect(host string, port, timeout int) (net.Conn, bool) {
 	// loop every three seconds until timeout
 	for i := 0; i < timeout; i += 3 {
 		// TCPConnect is proxy aware, so it will use the proxy if configured

--- a/c2/sslshell/sslshellserver.go
+++ b/c2/sslshell/sslshellserver.go
@@ -68,7 +68,7 @@ func (shellServer *Server) Init(ipAddr string, port int, isClient bool) bool {
 	var ok bool
 	var err error
 	var certificate tls.Certificate
-	if len(shellServer.CertificateFile) != 0 && len(shellServer.PrivateKeyFile) != 0 {
+	if shellServer.CertificateFile != "" && shellServer.PrivateKeyFile != "" {
 		certificate, err = tls.LoadX509KeyPair(shellServer.CertificateFile, shellServer.PrivateKeyFile)
 		if err != nil {
 			output.PrintfFrameworkError("Error loading certificate: %s", err.Error())

--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -39,10 +39,10 @@ func generateIPv4CIDR(cidr string) []string {
 	return cidrSlice
 }
 
-func buildRhosts(conf *config.Config, rhosts string, rports string) bool {
+func buildRhosts(conf *config.Config, rhosts, rports string) bool {
 	// convert the provided Rports to a slice of int
 	rportsSlice := make([]int, 0)
-	if len(rports) != 0 {
+	if rports != "" {
 		splitPorts := strings.Split(rports, ",")
 		for _, port := range splitPorts {
 			portInt, err := strconv.Atoi(port)
@@ -59,7 +59,7 @@ func buildRhosts(conf *config.Config, rhosts string, rports string) bool {
 
 	// convert the rhosts csv into a slice of strings
 	rhostsSlice := make([]string, 0)
-	if len(rhosts) != 0 {
+	if rhosts != "" {
 		splitRhosts := strings.Split(rhosts, ",")
 		for _, host := range splitRhosts {
 			if strings.Contains(host, "/") {
@@ -128,7 +128,7 @@ func parseRhostsFile(conf *config.Config, rhostsFile string) bool {
 
 		// determine the SSL status to assign everything
 		SSL := config.SSLDisabled
-		if len(splitTriplet[2]) != 0 {
+		if splitTriplet[2] != "" {
 			SSL = config.SSLEnabled
 		}
 
@@ -149,33 +149,33 @@ func parseRhostsFile(conf *config.Config, rhostsFile string) bool {
 	return true
 }
 
-func handleRhostsOptions(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
-	if len(rhostsFile) != 0 {
+func handleRhostsOptions(conf *config.Config, rhosts, rports, rhostsFile string) bool {
+	if rhostsFile != "" {
 		return parseRhostsFile(conf, rhostsFile)
 	}
 
 	return buildRhosts(conf, rhosts, rports)
 }
 
-func commonValidate(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
+func commonValidate(conf *config.Config, rhosts, rports, rhostsFile string) bool {
 	switch {
-	case len(conf.Rhost) == 0 && len(rhosts) == 0 && len(rhostsFile) == 0:
+	case conf.Rhost == "" && rhosts == "" && rhostsFile == "":
 		output.PrintFrameworkError("Missing required option 'rhost', 'rhosts', or 'rhosts-file'")
 
 		return false
-	case conf.Rport == 0 && len(rports) == 0 && len(rhostsFile) == 0:
+	case conf.Rport == 0 && rports == "" && rhostsFile == "":
 		output.PrintFrameworkError("Missing required option 'rport', 'rports', or 'rhosts-file'")
 
 		return false
-	case len(conf.Rhost) != 0 && len(rhosts) != 0:
+	case conf.Rhost != "" && rhosts != "":
 		output.PrintFrameworkError("'rhost' and 'rhosts' are mutually exclusive")
 
 		return false
-	case len(conf.Rhost) != 0 && len(rhostsFile) != 0:
+	case conf.Rhost != "" && rhostsFile != "":
 		output.PrintFrameworkError("'rhost' and 'rhosts-file' are mutually exclusive")
 
 		return false
-	case len(rhosts) != 0 && len(rhostsFile) != 0:
+	case rhosts != "" && rhostsFile != "":
 		output.PrintFrameworkError("'rhosts' and 'rhosts-file' are mutually exclusive")
 
 		return false
@@ -189,7 +189,7 @@ func commonValidate(conf *config.Config, rhosts string, rports string, rhostsFil
 		return false
 	}
 
-	if len(rhostsFile) != 0 {
+	if rhostsFile != "" {
 		_, err := os.Stat(rhostsFile)
 		if err != nil {
 			output.PrintfFrameworkError("Failed to stat %s: %s", rhostsFile, err)
@@ -210,7 +210,7 @@ func proxyFlags(proxy *string) {
 // handle HTTPS proxying (if HTTPS_PROXY env is set). It can't handle normal tcp socket proxying
 // though, so we'll set ALL_PROXY for that (and handle the logic in protocol/tcpsocket.go).
 func handleProxyOptions(proxy string) {
-	if len(proxy) == 0 {
+	if proxy == "" {
 		return
 	}
 	os.Setenv("HTTP_PROXY", proxy)
@@ -219,7 +219,7 @@ func handleProxyOptions(proxy string) {
 }
 
 // command line options for logging.
-func loggingFlags(logFile *string, frameworkLogLevel *string, exploitLogLevel *string) {
+func loggingFlags(logFile, frameworkLogLevel, exploitLogLevel *string) {
 	flag.BoolVar(&output.FormatJSON, "log-json", false, "Indicates if logging should use JSON")
 	flag.StringVar(logFile, "log-file", "", "The file to write log messages to.")
 
@@ -232,7 +232,7 @@ func loggingFlags(logFile *string, frameworkLogLevel *string, exploitLogLevel *s
 	flag.StringVar(exploitLogLevel, "ell", "STATUS", "The minimum log level for the exploit:"+logLevels)
 }
 
-func handleLogOptions(logFile string, frameworkLogLevel string, exploitLogLevel string) bool {
+func handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel string) bool {
 	value, found := output.LogLevels[frameworkLogLevel]
 	if !found {
 		output.PrintFrameworkError("Invalid framework log level provided")
@@ -249,7 +249,7 @@ func handleLogOptions(logFile string, frameworkLogLevel string, exploitLogLevel 
 	}
 	output.SetExploitLogLevel(value)
 
-	if len(logFile) != 0 && !output.SetOutputFile(logFile) {
+	if logFile != "" && !output.SetOutputFile(logFile) {
 		return false
 	}
 
@@ -257,7 +257,7 @@ func handleLogOptions(logFile string, frameworkLogLevel string, exploitLogLevel 
 }
 
 // command line flags for defining the remote host.
-func remoteHostFlags(conf *config.Config, rhosts *string, rhostsFile *string, rports *string) {
+func remoteHostFlags(conf *config.Config, rhosts, rhostsFile, rports *string) {
 	flag.StringVar(&conf.Rhost, "rhost", "", "The remote target's IP address")
 	flag.StringVar(rhosts, "rhosts", "", "A comma delimited list of remote target IP addresses")
 	flag.StringVar(rhostsFile, "rhosts-file", "", "A CSV containing a list of targets")
@@ -361,7 +361,7 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 		}
 		conf.C2Type = c2Selected
 
-		if conf.Bport == 0 && (conf.Lport == 0 || len(conf.Lhost) == 0) {
+		if conf.Bport == 0 && (conf.Lport == 0 || conf.Lhost == "") {
 			output.PrintFrameworkError("Missing exploitation options (bindshell or reverse shell)")
 			success = false
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	ThirdPartyC2Server bool
 }
 
-func New(extype ExploitType, supportedC2 []c2.Impl, product string, cve string, defaultPort int) *Config {
+func New(extype ExploitType, supportedC2 []c2.Impl, product, cve string, defaultPort int) *Config {
 	returnVal := new(Config)
 	returnVal.ExType = extype
 	returnVal.SupportedC2 = supportedC2

--- a/java/ldapjndi/ldapjndi.go
+++ b/java/ldapjndi/ldapjndi.go
@@ -59,7 +59,7 @@ func handleBind(w ldap.ResponseWriter, _ *ldap.Message) {
 // Accept the incoming request. Verify it is asking for the correct endpoint
 // and then send the user's requested gadget'.
 func handleSearch(writer ldap.ResponseWriter, msg *ldap.Message) {
-	if len(globalSerializedPayload) == 0 {
+	if globalSerializedPayload == "" {
 		output.PrintFrameworkError("A serialized payload was never configured!")
 	}
 
@@ -111,7 +111,7 @@ func CreateLDAPServer(name string) *ldap.Server {
 	return server
 }
 
-func SetLDAPGadget(gadget GadgetName, binary string, lhost string, lport int, command string) {
+func SetLDAPGadget(gadget GadgetName, binary, lhost string, lport int, command string) {
 	switch gadget {
 	case TomcatNashornReverseShell:
 		globalSerializedPayload = createTomcatNashornReverseShell(binary, lhost, lport)
@@ -166,7 +166,7 @@ func SetLDAPHTTPClass(gadget GadgetName, lhost string, lport int, httpHost strin
 // "10.9.49.242" -> lhost
 // 1270 -> lport
 // The change in size will then be accounted for in the padding variable.
-func createTomcatNashornReverseShell(binary string, lhost string, lport int) string {
+func createTomcatNashornReverseShell(binary, lhost string, lport int) string {
 	shellPayload := "\xac\xed" +
 		"\x00\x05\x73\x72\x00\x1d\x6f\x72\x67\x2e\x61\x70\x61\x63\x68\x65" +
 		"\x2e\x6e\x61\x6d\x69\x6e\x67\x2e\x52\x65\x73\x6f\x75\x72\x63\x65" +

--- a/output/exploitlog.go
+++ b/output/exploitlog.go
@@ -78,7 +78,7 @@ func PrintWarn(msg string, keys ...any) {
 
 // PrintVersion logs a string as VERSION
 // If the exploit is not logging to file, this will go to standard output.
-func PrintVersion(msg string, host string, port int, version string) {
+func PrintVersion(msg, host string, port int, version string) {
 	doExploitLog(stdErrDesc, LevelVersion, msg, "host", host, "port", port, "version", version)
 }
 

--- a/payload/encode.go
+++ b/payload/encode.go
@@ -35,7 +35,7 @@ func EncodeEchoBase64ToBash(cmd string) string {
 //	    return false
 //	}
 //	cron, xploit := payload.SelfRemovingCron("root", cronPath, xploitPath, xploit)
-func SelfRemovingCron(user string, cronPath string, xploitPath string, payload string) (string, string) {
+func SelfRemovingCron(user, cronPath, xploitPath, payload string) (string, string) {
 	cron := fmt.Sprintf("* * * * * %s /bin/sh %s\n", user, xploitPath)
 	xploit := fmt.Sprintf("#!/bin/sh\n\nrm -f %s\nrm -f %s\n%s\n", cronPath, xploitPath, payload)
 

--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -101,7 +101,7 @@ var factory = sc.getSocketFactory();
 var s=factory.createSocket("%s", %d);
 s.startHandshake()`, lhost, lport)
 	} else {
-		script += fmt.Sprintf(`var s=new java.net.Socket("%s", %d);`, lhost, lport)
+		script += fmt.Sprintf(`var s=new java.net.Socket(%q, %d);`, lhost, lport)
 	}
 	script += `
 var socketInput = new java.io.BufferedReader(new java.io.InputStreamReader(s.getInputStream()));

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -76,7 +76,7 @@ func ParseCookies(resp *http.Response) string {
 }
 
 // Go doesn't always like sending our exploit URI so use this raw version. SSL not implemented.
-func DoRawHTTPRequest(rhost string, rport int, uri string, verb string) bool {
+func DoRawHTTPRequest(rhost string, rport int, uri, verb string) bool {
 	// connect
 	conn, success := TCPConnect(rhost, rport)
 	if !success {
@@ -155,7 +155,7 @@ func SetRequestHeaders(req *http.Request, headers map[string]string) {
 	}
 }
 
-func CreateRequest(verb string, url string, payload string, followRedirect bool) (*http.Client, *http.Request, bool) {
+func CreateRequest(verb, url, payload string, followRedirect bool) (*http.Client, *http.Request, bool) {
 	var client *http.Client
 	if !followRedirect {
 		client = &http.Client{
@@ -182,7 +182,7 @@ func CreateRequest(verb string, url string, payload string, followRedirect bool)
 	return client, req, false
 }
 
-func HTTPSendAndRecv(verb string, url string, payload string) (*http.Response, string, bool) {
+func HTTPSendAndRecv(verb, url, payload string) (*http.Response, string, bool) {
 	client, req, err := CreateRequest(verb, url, payload, true)
 	if err {
 		return nil, "", false
@@ -191,7 +191,7 @@ func HTTPSendAndRecv(verb string, url string, payload string) (*http.Response, s
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvNoRedirect(verb string, url string, payload string) (*http.Response, string, bool) {
+func HTTPSendAndRecvNoRedirect(verb, url, payload string) (*http.Response, string, bool) {
 	client, req, err := CreateRequest(verb, url, payload, true)
 	if err {
 		return nil, "", false
@@ -205,7 +205,7 @@ func HTTPSendAndRecvNoRedirect(verb string, url string, payload string) (*http.R
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvURLEncoded(verb string, url string, params map[string]string) (*http.Response, string, bool) {
+func HTTPSendAndRecvURLEncoded(verb, url string, params map[string]string) (*http.Response, string, bool) {
 	payload := CreateRequestParams(params)
 	client, req, err := CreateRequest(verb, url, payload, true)
 	if err {
@@ -217,7 +217,7 @@ func HTTPSendAndRecvURLEncoded(verb string, url string, params map[string]string
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvURLEncodedParams(verb string, url string, params map[string]string) (*http.Response, string, bool) {
+func HTTPSendAndRecvURLEncodedParams(verb, url string, params map[string]string) (*http.Response, string, bool) {
 	payload := CreateRequestParamsEncoded(params)
 	client, req, err := CreateRequest(verb, url, payload, true)
 	if err {
@@ -229,7 +229,7 @@ func HTTPSendAndRecvURLEncodedParams(verb string, url string, params map[string]
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvURLEncodedAndHeaders(verb string, url string, params map[string]string,
+func HTTPSendAndRecvURLEncodedAndHeaders(verb, url string, params map[string]string,
 	headers map[string]string,
 ) (*http.Response, string, bool) {
 	payload := CreateRequestParams(params)
@@ -245,7 +245,7 @@ func HTTPSendAndRecvURLEncodedAndHeaders(verb string, url string, params map[str
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvURLEncodedParamsAndHeaders(verb string, url string, params map[string]string,
+func HTTPSendAndRecvURLEncodedParamsAndHeaders(verb, url string, params map[string]string,
 	headers map[string]string,
 ) (*http.Response, string, bool) {
 	payload := CreateRequestParamsEncoded(params)
@@ -261,7 +261,7 @@ func HTTPSendAndRecvURLEncodedParamsAndHeaders(verb string, url string, params m
 	return DoRequest(client, req)
 }
 
-func HTTPSendAndRecvWithHeaders(verb string, url string, payload string, headers map[string]string) (*http.Response, string, bool) {
+func HTTPSendAndRecvWithHeaders(verb, url, payload string, headers map[string]string) (*http.Response, string, bool) {
 	client, req, err := CreateRequest(verb, url, payload, true)
 	if err {
 		return nil, "", false
@@ -273,7 +273,7 @@ func HTTPSendAndRecvWithHeaders(verb string, url string, payload string, headers
 }
 
 // this naming scheme is a little out of control.
-func HTTPSendAndRecvWithHeadersNoRedirect(verb string, url string, payload string,
+func HTTPSendAndRecvWithHeadersNoRedirect(verb, url, payload string,
 	headers map[string]string,
 ) (*http.Response, string, bool) {
 	client, req, err := CreateRequest(verb, url, payload, true)
@@ -298,7 +298,7 @@ func MultipartCreateForm() (*strings.Builder, *multipart.Writer) {
 	return form, w
 }
 
-func MultipartAddField(writer *multipart.Writer, name string, value string) bool {
+func MultipartAddField(writer *multipart.Writer, name, value string) bool {
 	fw, err := writer.CreateFormField(name)
 	if err != nil {
 		return false
@@ -312,7 +312,7 @@ func MultipartAddFile(writer *multipart.Writer, name, filename, ctype, value str
 	// CreateFormFile doesn't expose Content-Type
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition",
-		fmt.Sprintf(`form-data; name="%s"; filename="%s"`, name, filename))
+		fmt.Sprintf(`form-data; name=%q; filename=%q`, name, filename))
 	h.Set("Content-Type", ctype)
 
 	fw, err := writer.CreatePart(h)

--- a/protocol/mikrotik/webfig.go
+++ b/protocol/mikrotik/webfig.go
@@ -84,7 +84,7 @@ func generateKeyPair() ([]byte, []byte) {
 	return privateKey, publicKey
 }
 
-func generateSharedKey(privateKey []byte, publicKey []byte) []byte {
+func generateSharedKey(privateKey, publicKey []byte) []byte {
 	sharedKey, _ := curve25519.X25519(reverseSlice(privateKey), reverseSlice(publicKey))
 
 	return reverseSlice(sharedKey)
@@ -234,7 +234,7 @@ func SendEncrypted(webfigURL string, msg *M2Message, session *WebfigSession) (*M
 
 // Given a username and password, this function will authenticate with
 // the remote router.
-func Login(webfigURL string, username string, password string, session *WebfigSession) bool {
+func Login(webfigURL, username, password string, session *WebfigSession) bool {
 	// create the login M2
 	msg := NewM2Message()
 	msg.AddString(1, []byte(username))
@@ -259,7 +259,7 @@ func Login(webfigURL string, username string, password string, session *WebfigSe
 
 // Upload a file via webfig. The expected url is: http[s]://<address>:<port>/jsproxy
 // The file will be written to /rw/disk and be viewable from the Webfig disk menu.
-func FileUpload(webfigURL string, filename string, contents string, session *WebfigSession) bool {
+func FileUpload(webfigURL, filename, contents string, session *WebfigSession) bool {
 	orginalName := filename
 
 	filename += strings.Repeat("\x20", 8)
@@ -289,7 +289,7 @@ func FileUpload(webfigURL string, filename string, contents string, session *Web
 	var multipartFile bytes.Buffer
 	writer := multipart.NewWriter(&multipartFile)
 	header := make(textproto.MIMEHeader)
-	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, orginalName))
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, orginalName))
 	header.Set("Content-Type", "form-data")
 	filedata, _ := writer.CreatePart(header)
 	_, _ = io.Copy(filedata, strings.NewReader(contents))

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -36,7 +36,7 @@ func Test_RandLetters(t *testing.T) {
 	}
 
 	letters = RandLetters(0)
-	if len(letters) != 0 {
+	if letters != "" {
 		t.Error("Failed to generate a 0 char string")
 	}
 
@@ -57,7 +57,7 @@ func Test_RandLettersNoBadChars(t *testing.T) {
 	// they don't contain a bad value.
 	for i := 0; i < 100; i++ {
 		letters := RandLettersNoBadChars(12, []rune("abcd"))
-		if len(letters) == 0 {
+		if letters == "" {
 			t.Error("RandLettersNoBadChars created an empty string")
 		}
 		for _, value := range letters {


### PR DESCRIPTION
This PR extends golangci-lint's config with some enabled [`gocritic`](https://go-critic.com/overview.html) checks. Also, fixed found gocritic issues.

### Rules explanation

- `emptyStringTest` is useful to distinguish slice len check with string. See https://dmitri.shuralyov.com/idiomatic-go#empty-string-check;
- `paramTypeCombine` and `sprintfQuotedString` shorten code.

### The full golangci-lint log
```sh
❯ golangci-lint run
output/exploitlog.go:81:1: paramTypeCombine: func(msg string, host string, port int, version string) could be replaced with func(msg, host string, port int, version string) (gocritic)
func PrintVersion(msg string, host string, port int, version string) {
^
payload/encode.go:38:1: paramTypeCombine: func(user string, cronPath string, xploitPath string, payload string) (string, string) could be replaced with func(user, cronPath, xploitPath, payload string) (string, string) (gocritic)
func SelfRemovingCron(user string, cronPath string, xploitPath string, payload string) (string, string) {
^
payload/reverse.go:104:13: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
                script += fmt.Sprintf(`var s=new java.net.Socket("%s", %d);`, lhost, lport)
                          ^
random/random_test.go:39:5: emptyStringTest: replace `len(letters) != 0` with `letters != ""` (gocritic)
        if len(letters) != 0 {
           ^
random/random_test.go:60:6: emptyStringTest: replace `len(letters) == 0` with `letters == ""` (gocritic)
                if len(letters) == 0 {
                   ^
protocol/httphelper.go:79:1: paramTypeCombine: func(rhost string, rport int, uri string, verb string) bool could be replaced with func(rhost string, rport int, uri, verb string) bool (gocritic)
func DoRawHTTPRequest(rhost string, rport int, uri string, verb string) bool {
^
protocol/httphelper.go:158:1: paramTypeCombine: func(verb string, url string, payload string, followRedirect bool) (*http.Client, *http.Request, bool) could be replaced with func(verb, url, payload string, followRedirect bool) (*http.Client, *http.Request, bool) (gocritic)
func CreateRequest(verb string, url string, payload string, followRedirect bool) (*http.Client, *http.Request, bool) {
^
protocol/httphelper.go:185:1: paramTypeCombine: func(verb string, url string, payload string) (*http.Response, string, bool) could be replaced with func(verb, url, payload string) (*http.Response, string, bool) (gocritic)
func HTTPSendAndRecv(verb string, url string, payload string) (*http.Response, string, bool) {
^
protocol/httphelper.go:194:1: paramTypeCombine: func(verb string, url string, payload string) (*http.Response, string, bool) could be replaced with func(verb, url, payload string) (*http.Response, string, bool) (gocritic)
func HTTPSendAndRecvNoRedirect(verb string, url string, payload string) (*http.Response, string, bool) {
^
protocol/httphelper.go:208:1: paramTypeCombine: func(verb string, url string, params map[string]string) (*http.Response, string, bool) could be replaced with func(verb, url string, params map[string]string) (*http.Response, string, bool) (gocritic)
func HTTPSendAndRecvURLEncoded(verb string, url string, params map[string]string) (*http.Response, string, bool) {
^
protocol/httphelper.go:220:1: paramTypeCombine: func(verb string, url string, params map[string]string) (*http.Response, string, bool) could be replaced with func(verb, url string, params map[string]string) (*http.Response, string, bool) (gocritic)
func HTTPSendAndRecvURLEncodedParams(verb string, url string, params map[string]string) (*http.Response, string, bool) {
^
protocol/httphelper.go:264:1: paramTypeCombine: func(verb string, url string, payload string, headers map[string]string) (*http.Response, string, bool) could be replaced with func(verb, url, payload string, headers map[string]string) (*http.Response, string, bool) (gocritic)
func HTTPSendAndRecvWithHeaders(verb string, url string, payload string, headers map[string]string) (*http.Response, string, bool) {
^
protocol/httphelper.go:301:1: paramTypeCombine: func(writer *multipart.Writer, name string, value string) bool could be replaced with func(writer *multipart.Writer, name, value string) bool (gocritic)
func MultipartAddField(writer *multipart.Writer, name string, value string) bool {
^
protocol/httphelper.go:315:3: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
                fmt.Sprintf(`form-data; name="%s"; filename="%s"`, name, filename))
                ^
java/ldapjndi/ldapjndi.go:62:5: emptyStringTest: replace `len(globalSerializedPayload) == 0` with `globalSerializedPayload == ""` (gocritic)
        if len(globalSerializedPayload) == 0 {
           ^
java/ldapjndi/ldapjndi.go:114:1: paramTypeCombine: func(gadget GadgetName, binary string, lhost string, lport int, command string) could be replaced with func(gadget GadgetName, binary, lhost string, lport int, command string) (gocritic)
func SetLDAPGadget(gadget GadgetName, binary string, lhost string, lport int, command string) {
^
java/ldapjndi/ldapjndi.go:169:1: paramTypeCombine: func(binary string, lhost string, lport int) string could be replaced with func(binary, lhost string, lport int) string (gocritic)
func createTomcatNashornReverseShell(binary string, lhost string, lport int) string {
^
protocol/mikrotik/webfig.go:87:1: paramTypeCombine: func(privateKey []byte, publicKey []byte) []byte could be replaced with func(privateKey, publicKey []byte) []byte (gocritic)
func generateSharedKey(privateKey []byte, publicKey []byte) []byte {
^
protocol/mikrotik/webfig.go:237:1: paramTypeCombine: func(webfigURL string, username string, password string, session *WebfigSession) bool could be replaced with func(webfigURL, username, password string, session *WebfigSession) bool (gocritic)
func Login(webfigURL string, username string, password string, session *WebfigSession) bool {
^
protocol/mikrotik/webfig.go:262:1: paramTypeCombine: func(webfigURL string, filename string, contents string, session *WebfigSession) bool could be replaced with func(webfigURL, filename, contents string, session *WebfigSession) bool (gocritic)
func FileUpload(webfigURL string, filename string, contents string, session *WebfigSession) bool {
^
protocol/mikrotik/webfig.go:292:36: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
        header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, orginalName))
                                          ^
c2/httpservefile/httpservefile.go:212:5: emptyStringTest: replace `len(filename) == 0` with `filename == ""` (gocritic)
        if len(filename) == 0 {
           ^
c2/httpservefile/httpservefile.go:140:6: emptyStringTest: replace `len(httpServer.CertificateFile) != 0` with `httpServer.CertificateFile != ""` (gocritic)
                if len(httpServer.CertificateFile) != 0 && len(httpServer.PrivateKeyFile) != 0 {
                   ^
c2/httpservefile/httpservefile.go:98:5: emptyStringTest: replace `len(httpServer.FilesToServe) == 0` with `httpServer.FilesToServe == ""` (gocritic)
        if len(httpServer.FilesToServe) == 0 {
           ^
c2/sslshell/sslshellserver.go:71:5: emptyStringTest: replace `len(shellServer.CertificateFile) != 0` with `shellServer.CertificateFile != ""` (gocritic)
        if len(shellServer.CertificateFile) != 0 && len(shellServer.PrivateKeyFile) != 0 {
           ^
c2/simpleshell/simpleshellclient.go:65:1: paramTypeCombine: func(host string, port int, timeout int) (net.Conn, bool) could be replaced with func(host string, port, timeout int) (net.Conn, bool) (gocritic)
func connect(host string, port int, timeout int) (net.Conn, bool) {
^
c2/httpserveshell/httpserveshell.go:77:5: emptyStringTest: replace `len(serveShell.HTTPAddr) == 0` with `serveShell.HTTPAddr == ""` (gocritic)
        if len(serveShell.HTTPAddr) == 0 {
           ^
c2/factory_test.go:30:5: emptyStringTest: replace `len(httpservefile.GetInstance().HostedFiles["factory.go"].RandomName) != 0` with `httpservefile.GetInstance().HostedFiles["factory.go"].RandomName != ""` (gocritic)
        if len(httpservefile.GetInstance().HostedFiles["factory.go"].RandomName) != 0 {
           ^
config/config.go:76:1: paramTypeCombine: func(extype ExploitType, supportedC2 []c2.Impl, product string, cve string, defaultPort int) *Config could be replaced with func(extype ExploitType, supportedC2 []c2.Impl, product, cve string, defaultPort int) *Config (gocritic)
func New(extype ExploitType, supportedC2 []c2.Impl, product string, cve string, defaultPort int) *Config {
^
cli/commandline.go:364:45: emptyStringTest: replace `len(conf.Lhost) == 0` with `conf.Lhost == ""` (gocritic)
                if conf.Bport == 0 && (conf.Lport == 0 || len(conf.Lhost) == 0) {
                                                          ^
cli/commandline.go:174:7: emptyStringTest: replace `len(conf.Rhost) != 0` with `conf.Rhost != ""` (gocritic)
        case len(conf.Rhost) != 0 && len(rhostsFile) != 0:
             ^
cli/commandline.go:170:7: emptyStringTest: replace `len(conf.Rhost) != 0` with `conf.Rhost != ""` (gocritic)
        case len(conf.Rhost) != 0 && len(rhosts) != 0:
             ^
cli/commandline.go:162:7: emptyStringTest: replace `len(conf.Rhost) == 0` with `conf.Rhost == ""` (gocritic)
        case len(conf.Rhost) == 0 && len(rhosts) == 0 && len(rhostsFile) == 0:
             ^
cli/commandline.go:252:5: emptyStringTest: replace `len(logFile) != 0` with `logFile != ""` (gocritic)
        if len(logFile) != 0 && !output.SetOutputFile(logFile) {
           ^
cli/commandline.go:213:5: emptyStringTest: replace `len(proxy) == 0` with `proxy == ""` (gocritic)
        if len(proxy) == 0 {
           ^
cli/commandline.go:62:5: emptyStringTest: replace `len(rhosts) != 0` with `rhosts != ""` (gocritic)
        if len(rhosts) != 0 {
           ^
cli/commandline.go:178:7: emptyStringTest: replace `len(rhosts) != 0` with `rhosts != ""` (gocritic)
        case len(rhosts) != 0 && len(rhostsFile) != 0:
             ^
cli/commandline.go:192:5: emptyStringTest: replace `len(rhostsFile) != 0` with `rhostsFile != ""` (gocritic)
        if len(rhostsFile) != 0 {
           ^
cli/commandline.go:153:5: emptyStringTest: replace `len(rhostsFile) != 0` with `rhostsFile != ""` (gocritic)
        if len(rhostsFile) != 0 {
           ^
cli/commandline.go:166:46: emptyStringTest: replace `len(rhostsFile) == 0` with `rhostsFile == ""` (gocritic)
        case conf.Rport == 0 && len(rports) == 0 && len(rhostsFile) == 0:
                                                    ^
cli/commandline.go:45:5: emptyStringTest: replace `len(rports) != 0` with `rports != ""` (gocritic)
        if len(rports) != 0 {
           ^
cli/commandline.go:131:6: emptyStringTest: replace `len(splitTriplet[2]) != 0` with `splitTriplet[2] != ""` (gocritic)
                if len(splitTriplet[2]) != 0 {
                   ^
cli/commandline.go:42:1: paramTypeCombine: func(conf *config.Config, rhosts string, rports string) bool could be replaced with func(conf *config.Config, rhosts, rports string) bool (gocritic)
func buildRhosts(conf *config.Config, rhosts string, rports string) bool {
^
cli/commandline.go:152:1: paramTypeCombine: func(conf *config.Config, rhosts string, rports string, rhostsFile string) bool could be replaced with func(conf *config.Config, rhosts, rports, rhostsFile string) bool (gocritic)
func handleRhostsOptions(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
^
cli/commandline.go:160:1: paramTypeCombine: func(conf *config.Config, rhosts string, rports string, rhostsFile string) bool could be replaced with func(conf *config.Config, rhosts, rports, rhostsFile string) bool (gocritic)
func commonValidate(conf *config.Config, rhosts string, rports string, rhostsFile string) bool {
^
cli/commandline.go:222:1: paramTypeCombine: func(logFile *string, frameworkLogLevel *string, exploitLogLevel *string) could be replaced with func(logFile, frameworkLogLevel, exploitLogLevel *string) (gocritic)
func loggingFlags(logFile *string, frameworkLogLevel *string, exploitLogLevel *string) {
^
cli/commandline.go:235:1: paramTypeCombine: func(logFile string, frameworkLogLevel string, exploitLogLevel string) bool could be replaced with func(logFile, frameworkLogLevel, exploitLogLevel string) bool (gocritic)
func handleLogOptions(logFile string, frameworkLogLevel string, exploitLogLevel string) bool {
^
cli/commandline.go:260:1: paramTypeCombine: func(conf *config.Config, rhosts *string, rhostsFile *string, rports *string) could be replaced with func(conf *config.Config, rhosts, rhostsFile, rports *string) (gocritic)
func remoteHostFlags(conf *config.Config, rhosts *string, rhostsFile *string, rports *string) {
^
```