### PR TITLE
Extend go.yml with lint step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,8 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.55

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters:
     - gci
     - gochecknoinits
     - gocognit
-    - goconst
+    #- goconst
     - gocritic
     - gocyclo
     - godot


### PR DESCRIPTION
This PR enables `golangci-lint` running on CI to prevent merging code with lint issues.

Also,  disable `goconst` because it's not so useful:
```
❯ golangci-lint run
java/javagadget.go:342:3: string `yloads/util/Gadg` has 3 occurrences, make it a constant (goconst)
                "\x79\x6c\x6f\x61\x64\x73\x2f\x75\x74\x69\x6c\x2f\x47\x61\x64\x67" +
                ^
java/javagadget.go:513:3: string `va.util.concurren` has 4 occurrences, make it a constant (goconst)
                "\x76\x61\x2e\x75\x74\x69\x6c\x2e\x63\x6f\x6e\x63\x75\x72\x72\x65\x6e" +
                ^
java/ldapjndi/ldapjndi.go:189:3: string `ntI
                                            elementCoun` has 3 occurrences, make it a constant (goconst)
                "\x6e\x74\x49\x00\x0c\x65\x6c\x65\x6d\x65\x6e\x74\x43\x6f\x75\x6e" +
                ^
java/ldapjndi/ldapjndi.go:199:3: string `xrjavax.naming` has 3 occurrences, make it a constant (goconst)
                "\x78\x72\x00\x14\x6a\x61\x76\x61\x78\x2e\x6e\x61\x6d\x69\x6e\x67" +
                ^
java/ldapjndi/ldapjndi.go:506:3: string `/sun/org/apache/` has 3 occurrences, make it a constant (goconst)
                "\x2f\x73\x75\x6e\x2f\x6f\x72\x67\x2f\x61\x70\x61\x63\x68\x65\x2f" +
                ^
java/ldapjndi/ldapjndi.go:194:3: string `bject;��X�s)l` has 3 occurrences, make it a constant (goconst)
                "\x62\x6a\x65\x63\x74\x3b\x90\xce\x58\x9f\x10\x73\x29\x6c\x02\x00" +
                ^
java/ldapjndi/ldapjndi.go:188:3: string `capacityIncreme` has 3 occurrences, make it a constant (goconst)
                "\x11\x63\x61\x70\x61\x63\x69\x74\x79\x49\x6e\x63\x72\x65\x6d\x65" +
                ^
java/ldapjndi/ldapjndi.go:191:3: string `[Ljava/lang/Ob` has 3 occurrences, make it a constant (goconst)
                "\x00\x13\x5b\x4c\x6a\x61\x76\x61\x2f\x6c\x61\x6e\x67\x2f\x4f\x62" +
                ^
java/ldapjndi/ldapjndi.go:179:3: string `addrstLjava/` has 3 occurrences, make it a constant (goconst)
                "\x00\x05\x61\x64\x64\x72\x73\x74\x00\x12\x4c\x6a\x61\x76\x61\x2f" +
                ^
java/ldapjndi/ldapjndi.go:204:3: string `sq~
                                            t   singl` has 3 occurrences, make it a constant (goconst)
                "\x00\x0f\x73\x71\x00\x7e\x00\x0b\x74\x00\x09\x73\x69\x6e\x67\x6c" +
                ^
```