### PR TITLE
Added timeout option

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vulncheck-oss/go-exploit/c2"
 	"github.com/vulncheck-oss/go-exploit/config"
 	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
 )
 
 // VulnCheck IPIntel data is shipped in single line JSON blobs. There is substantially more metadata, but
@@ -372,6 +373,8 @@ func remoteHostFlags(conf *config.Config, rhosts *string, rhostsFile *string, rp
 	// the Rport should be pre-configured to have a default value (see config.go:New())
 	flag.IntVar(&conf.Rport, "rport", conf.Rport, "The remote target's server port")
 	flag.StringVar(rports, "rports", "", "A comma delimited list of the remote target's server ports")
+	// generic all comms connection timeout
+	flag.IntVar(&protocol.GlobalCommTimeout, "timeout", 10, "The remote target's server port")
 }
 
 // command line flags for defining the local host.

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -16,8 +16,12 @@ import (
 	"github.com/vulncheck-oss/go-exploit/transform"
 )
 
+// GlobalUA is the default User-Agent for all go-exploit comms.
 var GlobalUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" +
 	"(KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36 Edg/105.0.1343.33"
+
+// GlobalCommTimeout is the default timeout for all socket communications.
+var GlobalCommTimeout = 10
 
 // Returns a valid HTTP/HTTPS URL provided the given input.
 func GenerateURL(rhost string, rport int, ssl bool, uri string) string {
@@ -157,16 +161,27 @@ func SetRequestHeaders(req *http.Request, headers map[string]string) {
 
 func CreateRequest(verb string, url string, payload string, followRedirect bool) (*http.Client, *http.Request, bool) {
 	var client *http.Client
+
 	if !followRedirect {
 		client = &http.Client{
-			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
+				}).Dial,
+			},
+			Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		}
 	} else {
 		client = &http.Client{
-			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
+				}).Dial,
+			},
+			Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 		}
 	}
 	req, err := http.NewRequest(verb, url, strings.NewReader(payload))

--- a/protocol/tcpsocket.go
+++ b/protocol/tcpsocket.go
@@ -48,7 +48,7 @@ func TCPConnect(host string, port int) (net.Conn, bool) {
 
 		// timeout long hanging connections
 		perHost := proxy.NewPerHost(dialer, proxy.Direct)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(GlobalCommTimeout)*time.Second)
 		defer cancel()
 		conn, err := perHost.DialContext(ctx, "tcp", target)
 		if err != nil {
@@ -61,7 +61,7 @@ func TCPConnect(host string, port int) (net.Conn, bool) {
 	}
 
 	// no proxy involved
-	conn, err := net.DialTimeout("tcp", target, 10*time.Second)
+	conn, err := net.DialTimeout("tcp", target, time.Duration(GlobalCommTimeout)*time.Second)
 	if err != nil {
 		output.PrintFrameworkError("Connection failed: " + err.Error())
 


### PR DESCRIPTION
See https://github.com/vulncheck-oss/go-exploit/issues/106

Before:

```sh
albinolobster@mournland:~/initial-access/feed/cve-2021-1473$ ./build/cve-2021-1473_linux-arm64 -v -rhost 8.8.8.8 -rport 5
time=2024-03-21T17:00:55.561-04:00 level=STATUS msg="Starting target" index=0 host=8.8.8.8 port=5 ssl=false "ssl auto"=false
time=2024-03-21T17:00:55.562-04:00 level=STATUS msg="Validating Cisco RV340/RV345 target" host=8.8.8.8 port=5
time=2024-03-21T17:01:05.565-04:00 level=ERROR msg="HTTP request error: Get \"http://8.8.8.8:5/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
time=2024-03-21T17:01:05.565-04:00 level=ERROR msg="The target isn't recognized as Cisco RV340/RV345, quitting" host=8.8.8.8 port=5 verified=false
```

After:
```sh
albinolobster@mournland:~/initial-access/feed/cve-2021-1473$ ./build/cve-2021-1473_linux-arm64 -v -rhost 8.8.8.8 -rport 5 -timeout 30
time=2024-03-21T17:03:37.754-04:00 level=STATUS msg="Starting target" index=0 host=8.8.8.8 port=5 ssl=false "ssl auto"=false
time=2024-03-21T17:03:37.754-04:00 level=STATUS msg="Validating Cisco RV340/RV345 target" host=8.8.8.8 port=5
time=2024-03-21T17:04:07.782-04:00 level=ERROR msg="HTTP request error: Get \"http://8.8.8.8:5/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
time=2024-03-21T17:04:07.782-04:00 level=ERROR msg="The target isn't recognized as Cisco RV340/RV345, quitting" host=8.8.8.8 port=5 verified=false
```

```sh
albinolobster@mournland:~/initial-access/feed/cve-2021-1473$ ./build/cve-2021-1473_linux-arm64 -v -rhost 8.8.8.8 -rport 5 -timeout 60
time=2024-03-21T17:15:25.376-04:00 level=STATUS msg="Starting target" index=0 host=8.8.8.8 port=5 ssl=false "ssl auto"=false
time=2024-03-21T17:15:25.376-04:00 level=STATUS msg="Validating Cisco RV340/RV345 target" host=8.8.8.8 port=5
time=2024-03-21T17:16:25.438-04:00 level=ERROR msg="HTTP request error: Get \"http://8.8.8.8:5/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
time=2024-03-21T17:16:25.438-04:00 level=ERROR msg="The target isn't recognized as Cisco RV340/RV345, quitting" host=8.8.8.8 port=5 verified=false
```