### PR TITLE
Moved TLSClientConfig out of Default Transport (SSL Verification Fix)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,7 +97,7 @@ issues:
       linters:
         - staticcheck
       text: SA1019
-    - path: framework.go
+    - path: httphelper.go
       linters:
         - staticcheck
       text: SA1019

--- a/framework.go
+++ b/framework.go
@@ -41,7 +41,6 @@ package exploit
 import (
 	"crypto/tls"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
@@ -329,13 +328,6 @@ func doScan(sploit Exploit, conf *config.Config) bool {
 func RunProgram(sploit Exploit, conf *config.Config) {
 	if !parseCommandLine(conf) {
 		return
-	}
-
-	// disable https cert verification globally
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
-		// We have no control over the SSL versions supported on the remote target. Be permissive for more targets.
-		MinVersion: tls.VersionSSL30,
 	}
 
 	// if the c2 server is meant to catch responses, initialize and start so it can bind

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -172,6 +173,11 @@ func CreateRequest(verb string, url string, payload string, followRedirect bool)
 				Dial: (&net.Dialer{
 					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 				}).Dial,
+				TLSClientConfig: (&tls.Config{
+					InsecureSkipVerify: true,
+					// We have no control over the SSL versions supported on the remote target. Be permissive for more targets.
+					MinVersion: tls.VersionSSL30,
+				}),
 			},
 			Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -184,6 +190,11 @@ func CreateRequest(verb string, url string, payload string, followRedirect bool)
 				Dial: (&net.Dialer{
 					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 				}).Dial,
+				TLSClientConfig: (&tls.Config{
+					InsecureSkipVerify: true,
+					// We have no control over the SSL versions supported on the remote target. Be permissive for more targets.
+					MinVersion: tls.VersionSSL30,
+				}),
 			},
 			Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 		}


### PR DESCRIPTION
I overwrote the default HTTP transport when adding the adjustable timeout logic to HTTP in https://github.com/vulncheck-oss/go-exploit/commit/e331b130f41f41e117bb674d8caa2150b02e5433 - Previously, we had just been putting `InsecureSkipVerify` in default transport, but that disappeared when we overwrote the default transport.

The fix is to push `InsecureSkipVerify` into httphelpers.go. Now we aren't polluting default transport.

https://github.com/vulncheck-oss/go-exploit/issues/113