### PR TITLE
Fix proxy support for http/https requests

### DIFF
--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -166,10 +166,10 @@ func SetRequestHeaders(req *http.Request, headers map[string]string) {
 // Creates the HTTP client, generates the HTTP request, and sets the default user-agent.
 func CreateRequest(verb string, url string, payload string, followRedirect bool) (*http.Client, *http.Request, bool) {
 	var client *http.Client
-
 	if !followRedirect {
 		client = &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				Dial: (&net.Dialer{
 					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 				}).Dial,
@@ -187,6 +187,7 @@ func CreateRequest(verb string, url string, payload string, followRedirect bool)
 	} else {
 		client = &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				Dial: (&net.Dialer{
 					Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 				}).Dial,
@@ -199,6 +200,7 @@ func CreateRequest(verb string, url string, payload string, followRedirect bool)
 			Timeout: time.Duration(GlobalCommTimeout) * time.Second,
 		}
 	}
+
 	req, err := http.NewRequest(verb, url, strings.NewReader(payload))
 	if err != nil {
 		output.PrintfFrameworkError("HTTP request creation error: %s", err)


### PR DESCRIPTION
Hello,

The proxy support was missed when creating a new http.Client with custom Transport{}.
Therefore the "-proxy" option had no effect on http/https connections. This PR reverts to the standard behavior of the go http client with os environ support.