### PR TITLE
Switch Error/Warning messages to Status messages

### DIFF
--- a/framework.go
+++ b/framework.go
@@ -168,7 +168,7 @@ func doVerify(sploit Exploit, conf *config.Config) bool {
 	output.PrintFrameworkStatus(
 		fmt.Sprintf("Validating %s target", conf.Product), "host", conf.Rhost, "port", conf.Rport)
 	if !sploit.ValidateTarget(conf) {
-		output.PrintFrameworkError(
+		output.PrintFrameworkStatus(
 			fmt.Sprintf("The target isn't recognized as %s, quitting", conf.Product), "host", conf.Rhost, "port", conf.Rport, "verified", false)
 
 		return false
@@ -184,7 +184,7 @@ func doVersionCheck(sploit Exploit, conf *config.Config) bool {
 	result := sploit.CheckVersion(conf)
 	switch result {
 	case NotVulnerable:
-		output.PrintFrameworkError("The target appears to be a patched version.", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "no")
+		output.PrintFrameworkStatus("The target appears to be a patched version.", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "no")
 
 		return false
 	case Vulnerable:
@@ -192,11 +192,11 @@ func doVersionCheck(sploit Exploit, conf *config.Config) bool {
 	case PossiblyVulnerable:
 		output.PrintFrameworkSuccess("The target *might* be a vulnerable version. Continuing.", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "possibly")
 	case Unknown:
-		output.PrintFrameworkError("The result of the version check returned an unknown state.", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "unknown")
+		output.PrintFrameworkStatus("The result of the version check returned an unknown state.", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "unknown")
 
 		return false
 	case NotImplemented:
-		output.PrintFrameworkWarn("This exploit has not implemented a version check", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "notimplemented")
+		output.PrintFrameworkStatus("This exploit has not implemented a version check", "host", conf.Rhost, "port", conf.Rport, "vulnerable", "notimplemented")
 	}
 
 	return true
@@ -291,7 +291,7 @@ func doScan(sploit Exploit, conf *config.Config) bool {
 			if ok {
 				output.PrintFrameworkSuccess("Exploit successfully completed", "exploited", true)
 			} else {
-				output.PrintFrameworkError("Exploit exited with an error", "exploited", false)
+				output.PrintFrameworkStatus("Exploit exited with an error", "exploited", false)
 			}
 		}()
 


### PR DESCRIPTION
stderr should only be used for actual errors and not to describe the state of scanning / exploitation.