### PR TITLE
#122 Allow user defined HTTP User-Agent

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -262,6 +262,9 @@ func handleRhostsOptions(conf *config.Config, rhosts string, rports string, rhos
 		return parseRhostsFile(conf, rhostsFile)
 	}
 
+	// dump the selected user agent to debug
+	output.PrintfFrameworkDebug("Using the HTTP User-Agent: %s", protocol.GlobalUA)
+
 	return buildRhosts(conf, rhosts, rports)
 }
 
@@ -375,6 +378,8 @@ func remoteHostFlags(conf *config.Config, rhosts *string, rhostsFile *string, rp
 	flag.StringVar(rports, "rports", "", "A comma delimited list of the remote target's server ports")
 	// generic all comms connection timeout
 	flag.IntVar(&protocol.GlobalCommTimeout, "timeout", 10, "A default timeout for all socket communication")
+	// allow the user to use their own HTTP user-agent if they so wish
+	flag.StringVar(&protocol.GlobalUA, "user-agent", protocol.GlobalUA, "The User-Agent to use in HTTP requests")
 }
 
 // command line flags for defining the local host.

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -96,7 +96,9 @@ func DoRawHTTPRequest(rhost string, rport int, uri string, verb string) bool {
 
 	httpRequest := verb + " " + uri + " HTTP/1.1\r\n"
 	httpRequest += "Host: " + rhost + ":" + strconv.Itoa(rport) + "\r\n"
-	httpRequest += "User-Agent: " + GlobalUA + "\r\n"
+	if len(GlobalUA) != 0 {
+		httpRequest += "User-Agent: " + GlobalUA + "\r\n"
+	}
 	httpRequest += "Accept: */*\r\n"
 	httpRequest += "\r\n"
 	success = TCPWrite(conn, []byte(httpRequest))


### PR DESCRIPTION
Added a command line option for a user to define the HTTP User-Agent to use. Example usage:

```sh
albinolobster@mournland:~/test$ ./user-agent-test -v -rhost 10.9.49.70 -fll DEBUG -user-agent "hello world"
time=2024-05-03T11:30:53.451-04:00 level=DEBUG msg="Using the HTTP User-Agent: hello world"
time=2024-05-03T11:30:53.451-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.70 port=80 ssl=false "ssl auto"=false
time=2024-05-03T11:30:53.452-04:00 level=STATUS msg="Validating My Target target" host=10.9.49.70 port=80
time=2024-05-03T11:30:53.453-04:00 level=ERROR msg="Received an unexpected HTTP status code: 502"
time=2024-05-03T11:30:53.453-04:00 level=STATUS msg="The target isn't recognized as My Target, quitting" host=10.9.49.70 port=80 verified=false
```

Results in:

![2024-05-03_11-52](https://github.com/vulncheck-oss/go-exploit/assets/113205286/f210f0a3-dde0-4034-a9c7-2b1c7556a5fa)

And you can now just remove the User-Agent by using "":

```sh
albinolobster@mournland:~/test$ ./user-agent-test -v -rhost 10.9.49.70 -fll DEBUG -user-agent ""
time=2024-05-03T11:30:43.822-04:00 level=DEBUG msg="Using the HTTP User-Agent: "
time=2024-05-03T11:30:43.823-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.70 port=80 ssl=false "ssl auto"=false
time=2024-05-03T11:30:43.823-04:00 level=STATUS msg="Validating My Target target" host=10.9.49.70 port=80
time=2024-05-03T11:30:43.824-04:00 level=ERROR msg="Received an unexpected HTTP status code: 502"
time=2024-05-03T11:30:43.824-04:00 level=STATUS msg="The target isn't recognized as My Target, quitting" host=10.9.49.70 port=80 verified=false
```

Results in:

![2024-05-03_11-55](https://github.com/vulncheck-oss/go-exploit/assets/113205286/a50f339f-9d65-422e-b98d-b05fc1782d80)

And, of course, the field is totally optional so if you don't use it, we just default to whatever the global ua is set to.

```
albinolobster@mournland:~/test$ ./user-agent-test -v -rhost 10.9.49.70 -fll DEBUG
time=2024-05-03T11:56:31.794-04:00 level=DEBUG msg="Using the HTTP User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36(KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36 Edg/105.0.1343.33"
time=2024-05-03T11:56:31.794-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.70 port=80 ssl=false "ssl auto"=false
time=2024-05-03T11:56:31.794-04:00 level=STATUS msg="Validating My Target target" host=10.9.49.70 port=80
time=2024-05-03T11:56:31.796-04:00 level=ERROR msg="Received an unexpected HTTP status code: 502"
time=2024-05-03T11:56:31.796-04:00 level=STATUS msg="The target isn't recognized as My Target, quitting" host=10.9.49.70 port=80 verified=fals
```

Results in:

![2024-05-03_11-58](https://github.com/vulncheck-oss/go-exploit/assets/113205286/44ed9f9a-135e-45f8-a181-727d9cb37a5f)

And, departing though, the user-agent output statement is debug only so it doesn't appear during normal usage:

```sh
albinolobster@mournland:~/test$ ./user-agent-test -v -rhost 10.9.49.70 
time=2024-05-03T11:59:11.364-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.70 port=80 ssl=false "ssl auto"=false
time=2024-05-03T11:59:11.364-04:00 level=STATUS msg="Validating My Target target" host=10.9.49.70 port=80
time=2024-05-03T11:59:11.366-04:00 level=ERROR msg="Received an unexpected HTTP status code: 502"
time=2024-05-03T11:59:11.366-04:00 level=STATUS msg="The target isn't recognized as My Target, quitting" host=10.9.49.70 port=80 verified=false
```