### PR TITLE
Clarify that flag.Parse() is ran internally

### DIFF
--- a/framework.go
+++ b/framework.go
@@ -324,6 +324,9 @@ func doScan(sploit Exploit, conf *config.Config) bool {
 // controls which targets are scanned, initiates call down into the exploits implementation
 // and is ultimately responsible for waiting for all c2 and attack threads to finish.
 //
+// This function also runs `flag.Parse()` so any defined flags will be parsed when RunProgram
+// is called.
+//
 // This function should be called by the implementing exploit, likely in the main function.
 func RunProgram(sploit Exploit, conf *config.Config) {
 	if !parseCommandLine(conf) {


### PR DESCRIPTION
Documents that flag.Parse() is handled by RunProgram in order to make it clear that you can define flags prior to this call and that handling them manually is unnecessary.