### PR TITLE
Docs: Update README to match new Payload links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The framework includes the following features:
 * Fully [proxy-aware](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/scanning.md#Proxy).
 * Key-value or JSON [output](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/output.md) for easy integration into other automated systems.
 * Builtin Java [gadgets](https://github.com/vulncheck-oss/go-exploit/blob/main/java/javagadget.go), [classes](https://github.com/vulncheck-oss/go-exploit/blob/main/java/javaclass.go), and [LDAP](https://github.com/vulncheck-oss/go-exploit/blob/main/java/ldapjndi/ldapjndi.go) infrastructure.
-* Many [reverse shell](https://github.com/vulncheck-oss/go-exploit/blob/main/payload/reverse.go) and [bind shell](https://github.com/vulncheck-oss/go-exploit/blob/main/payload/bind.go) payloads.
+* Many [reverse shell](https://github.com/vulncheck-oss/go-exploit/blob/main/payload/reverse), [dropper](https://github.com/vulncheck-oss/go-exploit/tree/main/payload/dropper), and [bind shell](https://github.com/vulncheck-oss/go-exploit/blob/main/payload/bindshell) payloads.
 * Functionality that integrates exploitation with other [tools](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/c2.md#using--o) or frameworks like [Metasploit](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/c2.md#using-httpservefile) and Sliver.
 * Builtin ["c2"](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/c2.md) for catching encrypted/unencrypted shells or hosting implants.
 * Supports multipe target [formats](https://github.com/vulncheck-oss/go-exploit/blob/main/docs/scanning.md#providing-targets) including lists, file-based, VulnCheck IP-Intel, and more.


### PR DESCRIPTION
Went through the docs and realized that he payload changes in #139 make the README point to a non-existent file. This clarifies and fixes that.