### PR TITLE
Make C2 timeout configurable by exploit

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -420,7 +420,12 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 
 	// flags unique to remote code execution
 	flag.IntVar(&conf.Bport, "bport", 0, "The port to attach the bind shell to")
-	flag.IntVar(&conf.C2Timeout, "t", 30, "The number of seconds to listen for reverse shells.")
+	// checks if the default values have been changed in the exploit directly
+	if conf.C2Timeout != 30 {
+		flag.IntVar(&conf.C2Timeout, "t", conf.C2Timeout, "The number of seconds to listen for reverse shells.")
+	} else {
+		flag.IntVar(&conf.C2Timeout, "t", 30, "The number of seconds to listen for reverse shells.")
+	}
 	flag.BoolVar(&conf.ThirdPartyC2Server, "o", false, "Indicates if the reverse shell should be caught by an outside program (nc, openssl)")
 
 	// c2 selection. defaults to the implementations first supported value


### PR DESCRIPTION
Currently the C2Timeout configuration option gets overwritten in the flag parsing when RunExploit is triggered. This change checks to see if the value is different than default and if so keeps the value and lets the exploit set the default timeout.

This is primarily useful when we utilize the cron payloads and other slow to respond or trigger vulnerabilities.