### PR TITLE
Updated example to contain multiple payload types

### DIFF
--- a/framework.go
+++ b/framework.go
@@ -10,9 +10,25 @@
 //		"github.com/vulncheck-oss/go-exploit"
 //		"github.com/vulncheck-oss/go-exploit/c2"
 //		"github.com/vulncheck-oss/go-exploit/config"
+//		"github.com/vulncheck-oss/go-exploit/output"
 //	)
 //
 //	type MyExploit struct{}
+//
+//	func generatePayload(conf *config.Config) (string, bool) {
+//	        generated := ""
+//
+//	        switch conf.C2Type {
+//	        case c2.SimpleShellServer:
+//	                // generated = reverse.Bash.TCPRedirection(conf.Lhost, conf.Lport) // Example
+//	        default:
+//	                output.PrintError("Invalid payload")
+//
+//	                return generated, false
+//	        }
+//
+//	        return generated, true
+//	}
 //
 //	func (sploit MyExploit) ValidateTarget(conf *config.Config) bool {
 //		return false
@@ -23,6 +39,10 @@
 //	}
 //
 //	func (sploit MyExploit) RunExploit(conf *config.Config) bool {
+//		generated, ok := generatePayload(conf)
+//	 	if !ok {
+//	     		return false
+//	 	}
 //		return true
 //	}
 //


### PR DESCRIPTION
In order to encourage folks to use multiple payload types (and to remind myself), I propose adding the payload generate function that is widely used by default.

This could be cleaned up if anyone (@wvu) has thoughts.