### PR TITLE
Add denial of service exploit type

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -534,6 +534,40 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 		commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
 }
 
+func DenialOfServiceCmdLineParse(conf *config.Config) bool {
+	var rhosts string
+	var rhostsFile string
+	var rports string
+	var logFile string
+	var frameworkLogLevel string
+	var exploitLogLevel string
+	var proxy string
+
+	proxyFlags(&proxy)
+	loggingFlags(&logFile, &frameworkLogLevel, &exploitLogLevel)
+	remoteHostFlags(conf, &rhosts, &rhostsFile, &rports)
+	localHostFlags(conf)
+	exploitFunctionality(conf)
+	sslFlags(conf)
+
+	flag.Usage = func() {
+		fmt.Printf("An exploit for %s %s that could crash the service\n\n", conf.Product, conf.CVE)
+
+		// print default usage information
+		flag.PrintDefaults()
+
+		// usage examples
+		fmt.Println("Usage example:")
+		fmt.Println("\t./exploit -v -c -e -a -rhost 10.12.70.247 -rport 443")
+	}
+	flag.Parse()
+
+	handleProxyOptions(proxy)
+
+	return handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
+		commonValidate(conf, rhosts, rports, rhostsFile) && handleRhostsOptions(conf, rhosts, rports, rhostsFile)
+}
+
 func WebShellCmdLineParse(conf *config.Config) bool {
 	var rhosts string
 	var rhostsFile string

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ const (
 	CodeExecution         ExploitType = 0
 	InformationDisclosure ExploitType = 1
 	Webshell              ExploitType = 2
+	DenialOfService       ExploitType = 3
 )
 
 type SSLSupport int

--- a/docs/exploit-types.md
+++ b/docs/exploit-types.md
@@ -5,6 +5,7 @@ The `go-exploit` framework currently supports three exploit types. These types d
 1. CodeExecution
 2. InformationDisclosure
 3. Webshell
+4. Denial of Service (DoS)
 
 To configure the exploit type in the exploit's `main` function, you can use the `config.New` function as follows:
 
@@ -45,6 +46,18 @@ conf := config.New(config.Webshell, []c2.Impl{}, "ThinkPHP", "CVE-2022-47945", 8
 ```
 
 Here is an example of invoking verification, version check, and exploitation using the WebShell exploit type:
+
+```sh
+./exploit -v -c -e -s -rhost 10.12.70.247 -rport 443
+```
+
+### Denial of Service
+
+The Denial of Service exploit type assumes that the exploit will attempt to crash or hang the target service. No command and control (C2) is configured for this exploit type. In the `main` function, it would look like this:
+
+```go
+conf := config.New(config.DenialOfService, []c2.Impl{}, "Asterisk", "CVE-2007-2293", 9000)
+```
 
 ```sh
 ./exploit -v -c -e -s -rhost 10.12.70.247 -rport 443

--- a/framework.go
+++ b/framework.go
@@ -229,6 +229,8 @@ func parseCommandLine(conf *config.Config) bool {
 		return cli.InformationDisclosureCmdLineParse(conf)
 	case config.Webshell:
 		return cli.WebShellCmdLineParse(conf)
+	case config.DenialOfService:
+		return cli.DenialOfServiceCmdLineParse(conf)
 	default:
 		output.PrintFrameworkError("Invalid exploit type provided.")
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vulncheck-oss/go-exploit
 go 1.22.2
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/lor00x/goldap v0.0.0-20240304151906-8d785c64d1c8
 	github.com/vjeantet/ldapserver v1.0.2-0.20240305064909-a417792e2906
 	golang.org/x/crypto v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3/go.mod h1:37YR9jabpiIxsb8X9VCIx8qFOjTDIIrIHHODa8C4gz0=
 github.com/lor00x/goldap v0.0.0-20240304151906-8d785c64d1c8 h1:z9RDOBcFcf3f2hSfKuoM3/FmJpt8M+w0fOy4wKneBmc=
 github.com/lor00x/goldap v0.0.0-20240304151906-8d785c64d1c8/go.mod h1:37YR9jabpiIxsb8X9VCIx8qFOjTDIIrIHHODa8C4gz0=


### PR DESCRIPTION
Does this make sense? I would like to re-write these ones:

- https://www.exploit-db.com/exploits/44181
- https://www.exploit-db.com/exploits/44182
- https://www.exploit-db.com/exploits/44183
- https://www.exploit-db.com/exploits/44184
- https://www.exploit-db.com/exploits/29900
- https://www.exploit-db.com/exploits/29901
- https://www.exploit-db.com/exploits/43992
- https://www.exploit-db.com/exploits/30974
- https://www.exploit-db.com/exploits/3407

Or should I simply use `Information Disclosure`?
