### PR TITLE
Only return cached item if body read was successful

### DIFF
--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -154,7 +154,6 @@ func cacheLookup(uri string) (*http.Response, string, bool) {
 		// didn't get any cache data. no big deal.
 		return nil, "", false
 	}
-	output.PrintfFrameworkTrace("HTTP cache hit: %s", uri)
 
 	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(cachedResp)), nil)
 	if err != nil {
@@ -164,7 +163,15 @@ func cacheLookup(uri string) (*http.Response, string, bool) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// seen this fail when, for example, Shodan messes with chunking
+		output.PrintFrameworkError(err.Error())
+
+		return nil, "", false
+	}
+
+	output.PrintfFrameworkTrace("HTTP cache hit: %s", uri)
 	bodyString := string(bodyBytes)
 
 	return resp, bodyString, true


### PR DESCRIPTION
I noticed this when working on integrating Shodan data. Basically, Shodan leaves the transfer-encoding chunked header, but removes the chunked values from the body. When Go attempts to read in the body, it fails. While I've accounted for this in our Shodan processor, I figured it was smart to account for it here too.