### PR TITLE
#210 Improve go-exploit self-documentation using new conf functions

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -471,6 +471,20 @@ func validateC2Selection(c2Selection string, conf *config.Config) bool {
 	return true
 }
 
+// Print the details of the implementation to the configured log.
+func printDetails(conf *config.Config) {
+	output.PrintSuccess("Implementation Details", "AssetDetection", conf.Impl.AssetDetection,
+		"VersionScanner", conf.Impl.VersionScanning,
+		"Exploitation", conf.Impl.Exploitation,
+		"Vendor", conf.Vendor,
+		"Products", conf.Products,
+		"CPE", conf.CPE,
+		"CVE", conf.CVE,
+		"Protocol", conf.Protocol,
+		"DefaultPort", conf.Rport,
+	)
+}
+
 // Parses the command line arguments used by RCE exploits.
 func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	var rhosts string
@@ -490,6 +504,7 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	exploitFunctionality(conf)
 	sslFlags(conf)
 	c2Flags(&c2Selection, conf)
+	detailsFlag := flag.Bool("details", false, "Print the implementation details for this exploit")
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -500,6 +515,11 @@ func CodeExecutionCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
+	if *detailsFlag {
+		printDetails(conf)
+
+		return false
+	}
 	handleProxyOptions(proxy)
 
 	// validate remaining command line arguments
@@ -548,6 +568,7 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	sslFlags(conf)
+	detailsFlag := flag.Bool("details", false, "Print the implementation details for this exploit")
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -562,6 +583,11 @@ func InformationDisclosureCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
+	if *detailsFlag {
+		printDetails(conf)
+
+		return false
+	}
 	handleProxyOptions(proxy)
 
 	return handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
@@ -584,6 +610,7 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	sslFlags(conf)
+	detailsFlag := flag.Bool("details", false, "Print the implementation details for this exploit")
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -598,6 +625,11 @@ func WebShellCmdLineParse(conf *config.Config) bool {
 	}
 	flag.Parse()
 
+	if *detailsFlag {
+		printDetails(conf)
+
+		return false
+	}
 	handleProxyOptions(proxy)
 
 	return handleLogOptions(logFile, frameworkLogLevel, exploitLogLevel) &&
@@ -650,6 +682,7 @@ func FormatFileCmdLineParse(conf *config.Config) bool {
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	c2Flags(&c2Selection, conf)
+	detailsFlag := flag.Bool("details", false, "Print the implementation details for this exploit")
 	flag.StringVar(&templateFile, "in", "", "The file format template to work with")
 	flag.StringVar(&conf.FileFormatFilePath, "out", "", "The file to write the malicious file to")
 
@@ -665,6 +698,12 @@ func FormatFileCmdLineParse(conf *config.Config) bool {
 		fmt.Println("\t./exploit -e -in <file> -out <file>")
 	}
 	flag.Parse()
+
+	if *detailsFlag {
+		printDetails(conf)
+
+		return false
+	}
 
 	if !loadFileFormatTemplate(templateFile, conf) {
 		return false
@@ -708,6 +747,7 @@ func LocalCmdLineParse(conf *config.Config) bool {
 	localHostFlags(conf)
 	exploitFunctionality(conf)
 	c2Flags(&c2Selection, conf)
+	detailsFlag := flag.Bool("details", false, "Print the implementation details for this exploit")
 
 	flag.Usage = func() {
 		// banner explaining what the software is
@@ -721,6 +761,12 @@ func LocalCmdLineParse(conf *config.Config) bool {
 		fmt.Println("\t./exploit -e")
 	}
 	flag.Parse()
+
+	if *detailsFlag {
+		printDetails(conf)
+
+		return false
+	}
 
 	// must be validate (to set default for payload gen) and then check third party c2
 	if !validateC2Selection(c2Selection, conf) && !conf.ThirdPartyC2Server {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/vulncheck-oss/go-exploit/c2"
 )
 
@@ -13,6 +16,12 @@ const (
 	FileFormat            ExploitType = 3
 	Local                 ExploitType = 4
 )
+
+type ImplementedFeatures struct {
+	AssetDetection  bool
+	VersionScanning bool
+	Exploitation    bool
+}
 
 type SSLSupport int
 
@@ -34,10 +43,20 @@ type RhostTriplet struct {
 type Config struct {
 	// the following are values configured by the exploit module
 
-	// the targeted product
+	// implemented features describes which three stages the exploit implements
+	Impl ImplementedFeatures
+	// the vendor of the targeted product
+	Vendor string
+	// the targeted products
+	Products []string
+	// A combination of the Vendor and Products strings
 	Product string
+	// the CPE for the targeted product
+	CPE []string
 	// the CVE being tested
 	CVE string
+	// the protocol being targeted
+	Protocol string
 	// the type of exploit being executed
 	ExType ExploitType
 	// the c2 supported by the exploit
@@ -81,6 +100,7 @@ type Config struct {
 	FileFormatFilePath string
 }
 
+// Deprecated: New does not affectively describe the affected/targeted product. Use NewRemoteExploit.
 func New(extype ExploitType, supportedC2 []c2.Impl, product string, cve string, defaultPort int) *Config {
 	returnVal := new(Config)
 	returnVal.ExType = extype
@@ -92,6 +112,7 @@ func New(extype ExploitType, supportedC2 []c2.Impl, product string, cve string, 
 	return returnVal
 }
 
+// Deprecated: NewLocal does not affectively describe the affected/targeted product. Use NewLocalExploit.
 func NewLocal(extype ExploitType, supportedC2 []c2.Impl, product string, cve string) *Config {
 	returnVal := new(Config)
 	returnVal.ExType = extype
@@ -100,4 +121,46 @@ func NewLocal(extype ExploitType, supportedC2 []c2.Impl, product string, cve str
 	returnVal.CVE = cve
 
 	return returnVal
+}
+
+// Defines a new remote exploit and associates with CVE/Product/Protocol metadata. Usage example:
+//
+//	conf := config.NewRemoteExploit(
+//	  config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
+//	  config.CodeExecution, []c2.Impl{c2.SimpleShellServer},
+//	  "Atlassian", []string{"Confluence"}, []string{"cpe:2.3:a:atlassian:confluence"},
+//	  "CVE-2023-22527", "HTTP", 8090)
+func NewRemoteExploit(implemented ImplementedFeatures, extype ExploitType, supportedC2 []c2.Impl, vendor string,
+	product []string, cpe []string, cve string, protocol string, defaultPort int,
+) *Config {
+	newConf := new(Config)
+	newConf.Impl = implemented
+	newConf.ExType = extype
+	newConf.SupportedC2 = supportedC2
+	newConf.Vendor = vendor
+	newConf.Products = product
+	newConf.Product = fmt.Sprintf("%s %s", vendor, strings.Join(product, "/"))
+	newConf.CPE = cpe
+	newConf.CVE = cve
+	newConf.Protocol = protocol
+	newConf.Rport = defaultPort
+
+	return newConf
+}
+
+// Defines a new remote exploit and associates with CVE/Product/Protocol metadata. Usage example:.
+func NewLocalExploit(implemented ImplementedFeatures, extype ExploitType, supportedC2 []c2.Impl, vendor string,
+	product []string, cpe []string, cve string,
+) *Config {
+	newConf := new(Config)
+	newConf.Impl = implemented
+	newConf.ExType = extype
+	newConf.SupportedC2 = supportedC2
+	newConf.Vendor = vendor
+	newConf.Products = product
+	newConf.Product = fmt.Sprintf("%s %s", vendor, strings.Join(product, "/"))
+	newConf.CPE = cpe
+	newConf.CVE = cve
+
+	return newConf
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,10 @@ func main() {
 		c2.SimpleShellServer,
 		c2.SimpleShellClient,
 	}
-	conf := config.New(config.CodeExecution, supportedC2, "My Target", "CVE-2023-1270", 80)
+    conf := config.NewRemoteExploit(
+        config.ImplementedFeatures{AssetDetection: false, VersionScanning: false, Exploitation: false},
+        config.CodeExecution, supportedC2, "Vendor", []string{"Product"},
+        []string{"cpe:2.3:a:vendor:product"}, "CVE-2024-1270", "HTTP", 8080)
 
 	sploit := MyExploit{}
 	exploit.RunProgram(sploit, conf)

--- a/framework.go
+++ b/framework.go
@@ -51,7 +51,10 @@
 //			c2.SimpleShellServer,
 //			c2.SimpleShellClient,
 //		}
-//		conf := config.New(config.CodeExecution, supportedC2, "My Target", "CVE-2023-1270", 80)
+//		conf := config.NewRemoteExploit(
+//			config.ImplementedFeatures{AssetDetection: false, VersionScanning: false, Exploitation: false},
+//			config.CodeExecution, supportedC2, "Vendor", []string{"Product"},
+//			[]string{"cpe:2.3:a:vendor:product"}, "CVE-2024-1270", "HTTP", 8080)
 //
 //		sploit := MyExploit{}
 //		exploit.RunProgram(sploit, conf)


### PR DESCRIPTION
This change introduces two new config.go functions:

1. NewRemoteExploit
2. NewLocalExploit

Additionally, it flags these old config.go functions as deprecated (and someday in the nearish future, they will simply be removed):

1. New
2. NewLocal

For those not familiar with the framework, these are core functions that *every* exploit calls in main. Using a public example, we can see that [this Confluence bug](https://github.com/vulncheck-oss/cve-2023-22527/blob/8275307ec52e8183354d85159b45fc3a4ded28ea/reverseshell/cve-2023-22527.go#L159) has a main like:

```go
func main() {
	supportedC2 := []c2.Impl{
		c2.SimpleShellServer,
	}
	conf := config.New(config.CodeExecution, supportedC2, "Confluence", "CVE-2023-22527", 8090)
```

But will need to be updated to something like:

```go
func main() {
	supportedC2 := []c2.Impl{
		c2.SimpleShellServer,
	}
	conf := config.NewRemoteExploit(
		config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
		config.CodeExecution, supportedC2, "Atlassian", []string{"Confluence"},
		[]string{"cpe:2.3:a:atlassian:confluence"}, "CVE-2023-22527", "HTTP", 8090)
```


The desire here is to properly document the targeted vendor, product, cpe, and protocol. Additionally, documenting which of the stages are implemented (target validation, version scanning, exploitation) is very useful for some future work we want to do. 

Finally, I added a `--details` flag that allows us to easily dump out this newly stored information.

```console
albinolobster@mournland:~/cve-2023-22527/reverseshell$ ./build/cve-2023-22527_linux-arm64 --details -log-json | jq
{
  "time": "2024-08-07T11:18:35.871766716-04:00",
  "level": "SUCCESS",
  "msg": "Implementation Details",
  "AssetDetection": true,
  "VersionScanner": true,
  "Exploitation": true,
  "Vendor": "Atlassian",
  "Products": [
    "Confluence"
  ],
  "CPE": [
    "cpe:2.3:a:atlassian:confluence"
  ],
  "CVE": "CVE-2023-22527",
  "Protocol": "HTTP",
  "DefaultPort": 8090
}
```

A bit of a critique on the actual implementation: I hate how verbose it is. Like there is a lot going on in that one function call... but it also has everything we need.