### PR TITLE
C2/external channel

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -473,10 +473,7 @@ func validateC2Selection(c2Selection string, conf *config.Config) bool {
 func printDetails(conf *config.Config) {
 	supportedC2Strings := make([]string, 0)
 	for _, value := range conf.SupportedC2 {
-		c2Name, ok := c2.ImplToString(value)
-		if ok {
-			supportedC2Strings = append(supportedC2Strings, c2Name)
-		}
+		supportedC2Strings = append(supportedC2Strings, value.Name)
 	}
 
 	output.PrintSuccess("Implementation Details",


### PR DESCRIPTION
Remove the devilish `ImplToString` now that we have `Impl.Name`.