### PR TITLE
Fix error message when using -o with local or file-based exploits

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -731,7 +731,7 @@ func FormatFileCmdLineParse(conf *config.Config) bool {
 	}
 
 	// must be validate (to set default for payload gen) and then check third party c2
-	if !validateC2Selection(c2Selection, conf) && !conf.ThirdPartyC2Server {
+	if !conf.ThirdPartyC2Server && !validateC2Selection(c2Selection, conf) {
 		return false
 	}
 	if !conf.ThirdPartyC2Server && (conf.Lport == 0 || len(conf.Lhost) == 0) {
@@ -775,7 +775,7 @@ func LocalCmdLineParse(conf *config.Config) bool {
 	}
 
 	// must be validate (to set default for payload gen) and then check third party c2
-	if !validateC2Selection(c2Selection, conf) && !conf.ThirdPartyC2Server {
+	if !conf.ThirdPartyC2Server && !validateC2Selection(c2Selection, conf) {
 		return false
 	}
 


### PR DESCRIPTION
I believe you ran into this too, @terrorbyte. Can you give this a test to ensure it resolves the issue?

e.g. This should fix the following ERROR message.

```
vulncheck@63960dc2030f:~$ ./xploit -v -c -e -o
time=2024-09-25T16:34:11.877Z level=ERROR msg="The c2 you selected is not supported by this exploit."
time=2024-09-25T16:34:11.878Z level=STATUS msg="Validating Sudo Project Sudo target" host="" port=0
```