### PR TITLE
Added Logic to Report Custom Exploit Flags

### DIFF
--- a/cli/commandline.go
+++ b/cli/commandline.go
@@ -27,6 +27,13 @@ type IPIntel struct {
 	SSL  bool   `json:"ssl"`
 }
 
+// A structure that defines the special flags this exploit implements.
+type CustomFlag struct {
+	Name    string
+	Type    string
+	Default string
+}
+
 // Increment the provided IP address.
 func inc(ip net.IP) {
 	for j := len(ip) - 1; j >= 0; j-- {
@@ -476,6 +483,36 @@ func printDetails(conf *config.Config) {
 		supportedC2Strings = append(supportedC2Strings, value.Name)
 	}
 
+	customFlags := make([]CustomFlag, 0)
+	for key, value := range conf.StringFlagsMap {
+		customFlags = append(customFlags, CustomFlag{
+			Name:    key,
+			Type:    fmt.Sprintf("%T", *value),
+			Default: fmt.Sprintf("%v", *value),
+		})
+	}
+	for key, value := range conf.UintFlagsMap {
+		customFlags = append(customFlags, CustomFlag{
+			Name:    key,
+			Type:    fmt.Sprintf("%T", *value),
+			Default: fmt.Sprintf("%v", *value),
+		})
+	}
+	for key, value := range conf.IntFlagsMap {
+		customFlags = append(customFlags, CustomFlag{
+			Name:    key,
+			Type:    fmt.Sprintf("%T", *value),
+			Default: fmt.Sprintf("%v", *value),
+		})
+	}
+	for key, value := range conf.BoolFlagsMap {
+		customFlags = append(customFlags, CustomFlag{
+			Name:    key,
+			Type:    fmt.Sprintf("%T", *value),
+			Default: fmt.Sprintf("%v", *value),
+		})
+	}
+
 	output.PrintSuccess("Implementation Details",
 		"ExploitType", fmt.Sprintf("%v", conf.ExType),
 		"AssetDetection", conf.Impl.AssetDetection,
@@ -488,6 +525,7 @@ func printDetails(conf *config.Config) {
 		"CVE", conf.CVE,
 		"Protocol", conf.Protocol,
 		"DefaultPort", conf.Rport,
+		"CustomFlags", customFlags,
 	)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/vulncheck-oss/go-exploit/c2"
+	"github.com/vulncheck-oss/go-exploit/output"
 )
 
 type ExploitType int
@@ -61,6 +63,15 @@ type Config struct {
 	ExType ExploitType
 	// the c2 supported by the exploit
 	SupportedC2 []c2.Impl
+
+	// Some exploits need to define custom flags. Use the Create*Flag functions
+	// to store them in the following data structures. They can then be fetched
+	// using the Get*Flag functions
+
+	StringFlagsMap map[string]*string
+	IntFlagsMap    map[string]*int
+	UintFlagsMap   map[string]*uint
+	BoolFlagsMap   map[string]*bool
 
 	// the following are values configured by the user
 
@@ -152,6 +163,7 @@ func NewRemoteExploit(implemented ImplementedFeatures, extype ExploitType, suppo
 	product []string, cpe []string, cve string, protocol string, defaultPort int,
 ) *Config {
 	newConf := new(Config)
+	newConf.InitFlagsStructs()
 	newConf.Impl = implemented
 	newConf.ExType = extype
 	newConf.SupportedC2 = supportedC2
@@ -171,6 +183,7 @@ func NewLocalExploit(implemented ImplementedFeatures, extype ExploitType, suppor
 	product []string, cpe []string, cve string,
 ) *Config {
 	newConf := new(Config)
+	newConf.InitFlagsStructs()
 	newConf.Impl = implemented
 	newConf.ExType = extype
 	newConf.SupportedC2 = supportedC2
@@ -181,4 +194,119 @@ func NewLocalExploit(implemented ImplementedFeatures, extype ExploitType, suppor
 	newConf.CVE = cve
 
 	return newConf
+}
+
+func (conf *Config) InitFlagsStructs() {
+	conf.StringFlagsMap = make(map[string]*string)
+	conf.IntFlagsMap = make(map[string]*int)
+	conf.UintFlagsMap = make(map[string]*uint)
+	conf.BoolFlagsMap = make(map[string]*bool)
+}
+
+// Create a command line flag for the string var "name" with the default value of "value" and
+// store the result locally.
+func (conf *Config) CreateStringFlag(name string, value string, usage string) {
+	valuePtr := &value
+	conf.StringFlagsMap[name] = valuePtr
+	flag.StringVar(conf.StringFlagsMap[name], name, value, usage)
+}
+
+// Create a command line flag for the string var "name" with the default value of "value" and
+// store the result locally *using an external "param" pointer*.
+func (conf *Config) CreateStringVarFlag(param *string, name string, value string, usage string) {
+	conf.StringFlagsMap[name] = param
+	flag.StringVar(param, name, value, usage)
+}
+
+// Create a command line flag for the uint var "name" with the default value of "value" and
+// store the result locally.
+func (conf *Config) CreateUintFlag(name string, value uint, usage string) {
+	valuePtr := &value
+	conf.UintFlagsMap[name] = valuePtr
+	flag.UintVar(conf.UintFlagsMap[name], name, value, usage)
+}
+
+// Create a command line flag for the uint var "name" with the default value of "value" and
+// store the result locally *using an external "param" pointer*.
+func (conf *Config) CreateUintVarFlag(param *uint, name string, value uint, usage string) {
+	conf.UintFlagsMap[name] = param
+	flag.UintVar(param, name, value, usage)
+}
+
+// Create a command line flag for the int var "name" with the default value of "value" and
+// store the result locally.
+func (conf *Config) CreateIntFlag(name string, value int, usage string) {
+	valuePtr := &value
+	conf.IntFlagsMap[name] = valuePtr
+	flag.IntVar(conf.IntFlagsMap[name], name, value, usage)
+}
+
+// Create a command line flag for the int var "name" with the default value of "value" and
+// store the result locally *using an external "param" pointer*.
+func (conf *Config) CreateIntVarFlag(param *int, name string, value int, usage string) {
+	conf.IntFlagsMap[name] = param
+	flag.IntVar(param, name, value, usage)
+}
+
+// Create a command line flag for the bool var "name" with the default value of "value" and
+// store the result locally.
+func (conf *Config) CreateBoolFlag(name string, value bool, usage string) {
+	valuePtr := &value
+	conf.BoolFlagsMap[name] = valuePtr
+	flag.BoolVar(conf.BoolFlagsMap[name], name, value, usage)
+}
+
+// Create a command line flag for the bool var "name" with the default value of "value" and
+// store the result locally *using an external "param" pointer*.
+func (conf *Config) CreateBoolVarFlag(param *bool, name string, value bool, usage string) {
+	conf.BoolFlagsMap[name] = param
+	flag.BoolVar(param, name, value, usage)
+}
+
+// Fetch the configured string value for "name".
+func (conf *Config) GetStringFlag(name string) string {
+	value, ok := conf.StringFlagsMap[name]
+	if !ok {
+		output.PrintfFrameworkError("Requested invalid flag: %s", name)
+
+		return ""
+	}
+
+	return *value
+}
+
+// Fetch the configured uint value for "name".
+func (conf *Config) GetUintFlag(name string) uint {
+	value, ok := conf.UintFlagsMap[name]
+	if !ok {
+		output.PrintfFrameworkError("Requested invalid flag: %s", name)
+
+		return 0
+	}
+
+	return *value
+}
+
+// Fetch the configured uint value for "name".
+func (conf *Config) GetIntFlag(name string) int {
+	value, ok := conf.IntFlagsMap[name]
+	if !ok {
+		output.PrintfFrameworkError("Requested invalid flag: %s", name)
+
+		return 0
+	}
+
+	return *value
+}
+
+// Fetch the configured uint value for "name".
+func (conf *Config) GetBoolFlag(name string) bool {
+	value, ok := conf.BoolFlagsMap[name]
+	if !ok {
+		output.PrintfFrameworkError("Requested invalid flag: %s", name)
+
+		return false
+	}
+
+	return *value
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,74 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/vulncheck-oss/go-exploit/c2"
+	"github.com/vulncheck-oss/go-exploit/config"
+)
+
+func TestDefaultFlags(t *testing.T) {
+	conf := config.NewRemoteExploit(
+		config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
+		config.CodeExecution, []c2.Impl{}, "Apache", []string{"OFBiz"},
+		[]string{"cpe:2.3:a:apache:ofbiz"}, "CVE-2024-45507", "HTTP", 80)
+
+	conf.CreateStringFlag("teststring1", "default!", "string usage")
+	conf.CreateUintFlag("testuint1", 99, "uint usage")
+	conf.CreateIntFlag("testint1", 300, "int usage")
+	conf.CreateBoolFlag("testbool1", true, "bool usage")
+
+	if conf.GetStringFlag("teststring1") != "default!" {
+		t.Error("Unexpected GetStringFlag results")
+	}
+	if conf.GetStringFlag("wat") != "" {
+		t.Error("Failed string lookup should default to empty string")
+	}
+	if conf.GetUintFlag("teststring1") != 0 {
+		t.Error("Failed uint lookup should default to 0")
+	}
+	if conf.GetUintFlag("testuint1") != 99 {
+		t.Error("Unexpected GetUintFlag results")
+	}
+	if conf.GetIntFlag("testint1") != 300 {
+		t.Error("Unexpected GetIntFlag results")
+	}
+	if !conf.GetBoolFlag("testbool1") {
+		t.Error("Unexpected GetBoolFlag results")
+	}
+}
+
+func TestExternalDefaultFlags(t *testing.T) {
+	conf := config.NewRemoteExploit(
+		config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
+		config.CodeExecution, []c2.Impl{}, "Apache", []string{"OFBiz"},
+		[]string{"cpe:2.3:a:apache:ofbiz"}, "CVE-2024-45507", "HTTP", 80)
+
+	testString := "test"
+	conf.CreateStringVarFlag(&testString, "teststring", "default!", "string usage")
+	testUInt := uint(88)
+	conf.CreateUintVarFlag(&testUInt, "testuint", 99, "uint usage")
+	testInt := -88
+	conf.CreateIntVarFlag(&testInt, "testint", 300, "int usage")
+	testBool := true
+	conf.CreateBoolVarFlag(&testBool, "testbool", true, "bool usage")
+
+	if conf.GetStringFlag("teststring") != "default!" {
+		t.Error("Unexpected GetStringFlag results")
+	}
+	if conf.GetStringFlag("wat") != "" {
+		t.Error("Failed string lookup should default to empty string")
+	}
+	if conf.GetUintFlag("teststring") != 0 {
+		t.Error("Failed uint lookup should default to 0")
+	}
+	if conf.GetUintFlag("testuint") != 99 {
+		t.Error("Unexpected GetUintFlag results")
+	}
+	if conf.GetIntFlag("testint") != 300 {
+		t.Error("Unexpected GetIntFlag results")
+	}
+	if !conf.GetBoolFlag("testbool") {
+		t.Error("Unexpected GetBoolFlag results")
+	}
+}


### PR DESCRIPTION
Currently, one of our stated goals it to make interoperability with other software easy. One thing that breaks that is when an exploit defines command line parameters that aren't generally well known. What I *don't* mean is like "lhost", "rhost", "proxy", etc. Those are all well known and easily mapped out to specific exploit types.

I'm talking about this scenario. Consider our implementation for CVE-2024-45507:

```go
func main() {
	httpServer := httpservefile.GetInstance()
	httpServer.CreateFlags()

	flag.StringVar(&httpServer.HTTPAddr, "httpAddr", "", "The address the HTTP server should bind to")
	flag.IntVar(&httpServer.HTTPPort, "httpPort", 8080, "The port the HTTP server should bind to")
	flag.StringVar(&globalHostname, "hostname", "localhost", "Hostname to use if not provided using rhost (default to rhost value or localhost)")

	supportedC2 := []c2.Impl{
		c2.SSLShellServer,
		c2.SimpleShellServer,
	}
	conf := config.NewRemoteExploit(
		config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
		config.CodeExecution, supportedC2, "Apache", []string{"OFBiz"},
		[]string{"cpe:2.3:a:apache:ofbiz"}, "CVE-2024-45507", "HTTP", 80)

	sploit := OFBizGroovyFetch{}
	exploit.RunProgram(sploit, conf)
}
```

Here we see the exploit define three flags. One of which is totally specific to the exploit (hostname) and two that are hooked into HTTPServeFile logic (we used httpservefile as the http server for this one... meta I actually like, but I digress).

From a "Let's use this programmatically to pwn the world" perspective, these are not great because (outside of the horrible `--help` menu) there is no way to discover them! So in this patch, I implement a way to bubble these three command line options into the `--details` view. 

First, let me share our CVE-2024-45507 was redefined (the diff is sort of messy since I moved stuff, so this is likely easier):

```go
func main() {
	supportedC2 := []c2.Impl{
		c2.SSLShellServer,
		c2.SimpleShellServer,
	}
	conf := config.NewRemoteExploit(
		config.ImplementedFeatures{AssetDetection: true, VersionScanning: true, Exploitation: true},
		config.CodeExecution, supportedC2, "Apache", []string{"OFBiz"},
		[]string{"cpe:2.3:a:apache:ofbiz"}, "CVE-2024-45507", "HTTP", 80)

	// This exploit requires an HTTP server so hijack the HTTPServeFile server
	httpServer := httpservefile.GetInstance()
	httpServer.CreateFlags()

	// Newer OFBiz requires the `host` field contain a hostname and not an IP address.
	// If the user provides a hostname using `rhost` we will use that, otherwise
	// we'll use this variable which is defaulted to `localhost` - the user can
	// alter it on the command line.
	conf.CreateStringFlag("hostname", "localhost", "Hostname to use if not provided using rhost (default to rhost value or localhost)")
	conf.CreateStringVarFlag(&httpServer.HTTPAddr, "httpAddr", "", "The address the HTTP server should bind to")
	conf.CreateIntVarFlag(&httpServer.HTTPPort, "httpPort", 8080, "The port the HTTP server should bind to")

	sploit := OFBizGroovyFetch{}
	exploit.RunProgram(sploit, conf)
}
```

Here you can see that instead of `flag` I'm using `conf.Create*Flag`. This actually eliminates the use of the globalHostname variable. Instead we using `conf.GetStringFlag("hostname")`:

```diff
 func (sploit OFBizGroovyFetch) CheckVersion(conf *config.Config) exploit.VersionCheckType {
-       hostname := globalHostname
+       hostname := conf.GetStringFlag("hostname")
        if net.ParseIP(conf.Rhost) == nil {
                hostname = conf.Rhost
        }
@@ -191,7 +184,7 @@ func hostXMLFile(filename string, cmd string) {
 
 func triggerExploit(conf *config.Config, decoratorURL string) bool {
        headers := map[string]string{
-               "Host": fmt.Sprintf("%s:%d", globalHostname, conf.Rport),
+               "Host": fmt.Sprintf("%s:%d", conf.GetStringFlag("hostname"), conf.Rport),
        }
```

Additionally, --details now knows all about these three variables and their types (see CustomFlags):

```console
albinolobster@mournland:~/initial-access/feed/cve-2024-45507$ ./build/cve-2024-45507_linux-arm64 --details --log-json | jq
{
  "time": "2024-10-04T13:04:03.285376637-04:00",
  "level": "SUCCESS",
  "msg": "Implementation Details",
  "ExploitType": "CodeExecution",
  "AssetDetection": true,
  "VersionScanner": true,
  "Exploitation": true,
  "SupportedC2": [
    "SSLShellServer",
    "SimpleShellServer"
  ],
  "Vendor": "Apache",
  "Products": [
    "OFBiz"
  ],
  "CPE": [
    "cpe:2.3:a:apache:ofbiz"
  ],
  "CVE": "CVE-2024-45507",
  "Protocol": "HTTP",
  "DefaultPort": 80,
  "CustomFlags": [
    {
      "Name": "hostname",
      "Type": "string",
      "Default": "localhost"
    },
    {
      "Name": "httpAddr",
      "Type": "string",
      "Default": ""
    },
    {
      "Name": "httpPort",
      "Type": "int",
      "Default": "8080"
    }
  ]
}
```

The actual implementation in `config.go` is not actually all that different from how `flag` works. They go the extra mile to mask types (although at the end of the day, they still have to define get/set for every type anyways and require type-oriented function anyways), but otherwise no big surprises. The parameters are stored in maps in `config.go` for easy lookup... and that's about it.